### PR TITLE
Fix vertical scrolling

### DIFF
--- a/src/comportexviz/viz_canvas.cljs
+++ b/src/comportexviz/viz_canvas.cljs
@@ -120,7 +120,7 @@
          (fn [r-lays]
            (mapv (fn [lay]
                    (let [n (n-onscreen lay)
-                         ncol (:elements-per-dt lay)]
+                         ncol (p/size (:topo lay))]
                      (update-in lay [:scroll-top]
                                (fn [x]
                                  (if down?


### PR DESCRIPTION
The calculation of the scrolling position seems broken (scrolled into negative values before). This change uses the topology size instead.
