### PR TITLE
Make the viz and timeline canvases into self-drawing components.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ pom.xml
 .lein-plugins
 .lein-cljsbuild-compiler*
 /public/*/out/
+/public/out/
 comportexviz*.js
 *.js.map
 *~

--- a/src/comportexviz/controls_ui.cljs
+++ b/src/comportexviz/controls_ui.cljs
@@ -386,26 +386,35 @@
         "Speed" [:span.caret]]
        [:ul.dropdown-menu {:role "menu"}
         [:li [:a {:href "#"
-                  :on-click #(swap! main-options assoc :sim-step-ms 0
-                                    :anim-every 1)}
+                  :on-click (fn []
+                              (swap! main-options assoc :sim-step-ms 0)
+                              (swap! viz-options assoc-in
+                                     [:drawing :anim-every] 1))}
               "max sim speed"]]
         [:li [:a {:href "#"
-                  :on-click #(swap! main-options assoc :sim-step-ms 0
-                                    :anim-every 100)}
+                  :on-click (fn []
+                              (swap! main-options assoc :sim-step-ms 0)
+                              (swap! viz-options assoc-in
+                                     [:drawing :anim-every] 100))}
               "max sim speed, draw every 100 steps"]]
         [:li [:a {:href "#"
-                  :on-click #(swap! main-options assoc :sim-step-ms 250
-                                    :anim-every 1)}
+                  :on-click (fn []
+                              (swap! main-options assoc :sim-step-ms 250)
+                              (swap! viz-options assoc-in
+                                     [:drawing :anim-every] 1))}
               "limit to 4 steps/sec."]]
         [:li [:a {:href "#"
-                  :on-click #(swap! main-options assoc :sim-step-ms 500
-                                    :anim-every 1)}
+                  :on-click (fn []
+                              (swap! main-options assoc :sim-step-ms 500)
+                              (swap! viz-options assoc-in
+                                     [:drawing :anim-every] 1))}
               "limit to 2 steps/sec."]]
         [:li [:a {:href "#"
-                  :on-click #(swap! main-options assoc :sim-step-ms 1000
-                                    :anim-every 1)}
-              "limit to 1 step/sec."]]
-        ]]
+                  :on-click (fn []
+                              (swap! main-options assoc :sim-step-ms 1000)
+                              (swap! viz-options assoc-in
+                                     [:drawing :anim-every] 1))}
+              "limit to 1 step/sec."]]]]
       [:li (if @show-help {:class "active"})
        [:a {:href "#"
             :on-click (fn [e]
@@ -483,35 +492,9 @@
         ]]]
      [:hr]]))
 
-(def code-key
-  {32 :space
-   33 :page-up
-   34 :page-down
-   37 :left
-   38 :up
-   39 :right
-   40 :down})
-
-(def key->control-k
-  {:left :step-backward
-   :right :step-forward
-   :up :column-up
-   :down :column-down
-   :page-up :scroll-up
-   :page-down :scroll-down
-   :space :toggle-run})
-
-(defn viz-key-down
-  [e controls]
-  (if-let [k (code-key (.-keyCode e))]
-    (let [control-fn (-> k key->control-k controls)]
-      (control-fn)
-      (.preventDefault e))
-    true))
-
 (defn comportexviz-app
-  [model-tab world-pane model main-options viz-options selection steps
-   viz-click timeline-click controls series-colors]
+  [model-tab main-pane model main-options viz-options selection steps controls
+   series-colors]
   (let [show-help (atom false)
         viz-expanded (atom false)]
     [:div
@@ -520,19 +503,7 @@
      [:div.container-fluid
       [:div.row
        [:div.col-sm-9.viz-expandable
-        [:canvas#comportex-timeline {:on-click timeline-click
-                                     :style {:width "100%"
-                                             :height "2em"}}]
-        [:div.row
-         [:div.col-sm-3.col-lg-2
-          [world-pane]]
-         [:div.col-sm-9.col-lg-10
-          [:canvas#comportex-viz {:on-click viz-click
-                                  :on-key-down (fn [e] (viz-key-down e controls))
-                                  :tabIndex 1
-                                  :style {:width "100%"
-                                          :height "100vh"}}]]]
-        ]
+        [main-pane]]
        [:div.col-sm-3
         [tabs
          [[:model [model-tab]]

--- a/src/comportexviz/main.cljs
+++ b/src/comportexviz/main.cljs
@@ -25,9 +25,7 @@
 
 (def main-options
   (atom {:sim-go? false
-         :sim-step-ms 200
-         :anim-go? true
-         :anim-every 1}))
+         :sim-step-ms 200}))
 
 ;;; ## Simulation
 
@@ -58,31 +56,6 @@
                         (not (:sim-go? old)))
                (run-sim))))
 
-;;; ## Visualisation
-
-(defn draw!
-  []
-  (.requestAnimationFrame js/window viz/draw!))
-
-(add-watch viz/viz-options :redraw
-           (fn [_ _ _ _]
-             (draw!)))
-
-(add-watch viz/selection :redraw
-           (fn [_ _ _ _]
-             (draw!)))
-
-;;; # Animation loop
-
-(go (loop [c (tap-c steps-mult)]
-      (when-let [htm (<! c)]
-        (let [t (p/timestep htm)
-              n (:anim-every @main-options)]
-          (when (and (:anim-go? @main-options)
-                     (zero? (mod t n)))
-            (draw!)))
-        (recur c))))
-
 (def controls
   {:step-backward viz/step-backward!
    :step-forward #(viz/step-forward! sim-step!)
@@ -97,11 +70,21 @@
 
 ;;; ## Entry point
 
+(defn main-pane [world-pane]
+  (fn []
+    [:div
+     [viz/viz-timeline]
+     [:div.row
+      [:div.col-sm-3.col-lg-2
+       [world-pane]]
+      [:div.col-sm-9.col-lg-10
+       [viz/viz-canvas {:tabIndex 1} controls]]]]))
+
 (defn comportexviz-app
   [model-tab world-pane]
   (viz/init! (tap-c steps-mult))
-  (cui/comportexviz-app model-tab world-pane model main-options viz/viz-options viz/selection
-                        viz/model-steps viz/viz-click viz/timeline-click controls
+  (cui/comportexviz-app model-tab (main-pane world-pane) model main-options
+                        viz/viz-options viz/selection viz/model-steps controls
                         viz/state-colors))
 
 (defn set-model!


### PR DESCRIPTION
Rather than having a draw loop, draw inside of the component's did-update React lifecycle method.

This makes the comportexviz canvas easier to reuse in other contexts, e.g. enabling multiple instances per page.