### PR TITLE
Remove global atoms from viz-canvas, enable commands with multiple canvases

### DIFF
--- a/examples/cortical_io/comportexviz/cortical_io_demo.cljs
+++ b/examples/cortical_io/comportexviz/cortical_io_demo.cljs
@@ -145,7 +145,7 @@ fox eat something.
   (let [show-predictions (atom false)
         predictions-cache (atom {})]
     (fn []
-      (when-let [htm (viz/selected-model-step)]
+      (when-let [htm (main/selected-model-step)]
         (let [in-value (:value (first (core/input-seq htm)))]
           [:div
            [:p.muted [:small "Input on selected timestep."]]
@@ -332,8 +332,8 @@ fox eat something.
 
 (defn ^:export init
   []
-  (reagent/render (main/comportexviz-app model-tab world-pane)
+  (reagent/render [main/comportexviz-app model-tab world-pane]
                   (dom/getElement "comportexviz-app"))
-  (swap! viz/viz-options assoc-in [:drawing :display-mode] :two-d)
+  (swap! main/viz-options assoc-in [:drawing :display-mode] :two-d)
   (reset! main/world world-c)
   (swap! main/main-options assoc :sim-go? true))

--- a/examples/demos/comportexviz/demos/coordinates_2d.cljs
+++ b/examples/demos/comportexviz/demos/coordinates_2d.cljs
@@ -3,7 +3,7 @@
             [org.nfrac.comportex.core :as core]
             [org.nfrac.comportex.util :as util :refer [round]]
             [comportexviz.main :as main]
-            [comportexviz.viz-canvas :as viz]
+            [comportexviz.helpers :as h]
             [comportexviz.plots-canvas :as plt]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]
@@ -108,12 +108,12 @@
 (defn on-resize
   [_]
   (when-let [el (dom/getElement "comportex-world")]
-    (viz/set-canvas-pixels-from-element-size! el 160)
+    (h/set-canvas-pixels-from-element-size! el 160)
     (swap! trigger-redraw inc)))
 
 (defn world-pane
   []
-  (when-let [htm (viz/selected-model-step)]
+  (when-let [htm (main/selected-model-step)]
     (let [in-value (:value (first (core/input-seq htm)))
           canvas (dom/getElement "comportex-world")]
       (when canvas
@@ -191,10 +191,10 @@
 
 (defn ^:export init
   []
-  (reagent/render (main/comportexviz-app model-tab world-pane)
+  (reagent/render [main/comportexviz-app model-tab world-pane]
                   (dom/getElement "comportexviz-app"))
   (.addEventListener js/window "resize" on-resize)
-  (swap! viz/viz-options assoc-in [:drawing :display-mode] :two-d)
+  (swap! main/viz-options assoc-in [:drawing :display-mode] :two-d)
   (reset! main/world world-c)
   (feed-world!)
   (set-model!))

--- a/examples/demos/comportexviz/demos/fixed_seqs.cljs
+++ b/examples/demos/comportexviz/demos/fixed_seqs.cljs
@@ -10,7 +10,7 @@
             [reagent-forms.core :refer [bind-fields]]
             [goog.dom :as dom]
             [goog.dom.forms :as forms]
-            [comportexviz.viz-canvas :as viz]
+            [comportexviz.helpers :as h]
             [comportexviz.plots-canvas :as plt]
             [monet.canvas :as c]
             [cljs.core.async :as async])
@@ -77,7 +77,7 @@
 (defn on-resize
   [_]
   (when-let [el (dom/getElement "comportex-world")]
-    (viz/set-canvas-pixels-from-element-size! el 160)
+    (h/set-canvas-pixels-from-element-size! el 160)
     (swap! trigger-redraw inc)))
 
 (defn pattern-index-map
@@ -96,7 +96,7 @@
 
 (defn world-pane
   []
-  (when-let [htm (viz/selected-model-step)]
+  (when-let [htm (main/selected-model-step)]
     (let [in-value (:value (first (core/input-seq htm)))
           model-id (::model-id (meta in-value))
           {:keys [patterns mixed? xy?]} (model-info model-id)
@@ -139,7 +139,7 @@
         model-id (:input-stream @config)
         {:keys [model-fn world-fn xy?]} (model-info model-id)]
     (async/close! @main/world)
-    (swap! viz/viz-options assoc-in [:drawing :display-mode]
+    (swap! main/viz-options assoc-in [:drawing :display-mode]
            (if (= model-id :isolated-2d) :two-d :one-d))
     (with-ui-loading-message
       (main/set-model! (model-fn n-regions))
@@ -226,7 +226,7 @@
 
 (defn ^:export init
   []
-  (reagent/render (main/comportexviz-app model-tab world-pane)
+  (reagent/render [main/comportexviz-app model-tab world-pane]
                   (dom/getElement "comportexviz-app"))
   (.addEventListener js/window "resize" on-resize)
   (swap! main/main-options assoc :sim-go? true))

--- a/examples/demos/comportexviz/demos/letters.cljs
+++ b/examples/demos/comportexviz/demos/letters.cljs
@@ -49,7 +49,7 @@ Chifung has a friend."))
   []
   (let [show-predictions (atom false)]
     (fn []
-      (when-let [htm (viz/selected-model-step)]
+      (when-let [htm (main/selected-model-step)]
        (let [in-value (:value (first (core/input-seq htm)))]
          [:div
           [:p.muted [:small "Input on selected timestep."]]
@@ -150,7 +150,7 @@ Chifung has a friend."))
 
 (defn ^:export init
   []
-  (reagent/render (main/comportexviz-app model-tab world-pane)
+  (reagent/render [main/comportexviz-app model-tab world-pane]
                   (dom/getElement "comportexviz-app"))
   (reset! main/world world-c)
   (set-model!)

--- a/examples/demos/comportexviz/demos/q_learning_1d.cljs
+++ b/examples/demos/comportexviz/demos/q_learning_1d.cljs
@@ -3,7 +3,7 @@
             [org.nfrac.comportex.core :as core]
             [org.nfrac.comportex.util :as util :refer [round abs]]
             [comportexviz.main :as main]
-            [comportexviz.viz-canvas :as viz]
+            [comportexviz.helpers :as h]
             [comportexviz.plots-canvas :as plt]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]
@@ -98,7 +98,7 @@
 (defn on-resize
   [_]
   (when-let [el (dom/getElement "comportex-world")]
-    (viz/set-canvas-pixels-from-element-size! el 160)
+    (h/set-canvas-pixels-from-element-size! el 160)
     (swap! trigger-redraw inc)))
 
 (defn signed-str [x] (str (if (neg? x) "" "+") x))
@@ -156,7 +156,7 @@
 
 (defn world-pane
   []
-  (when-let [htm (viz/selected-model-step)]
+  (when-let [htm (main/selected-model-step)]
     (let [in-value (:value (first (core/input-seq htm)))
           canvas (dom/getElement "comportex-world")]
       (when canvas
@@ -268,7 +268,7 @@
 
 (defn ^:export init
   []
-  (reagent/render (main/comportexviz-app model-tab world-pane)
+  (reagent/render [main/comportexviz-app model-tab world-pane]
                   (dom/getElement "comportexviz-app"))
   (.addEventListener js/window "resize" on-resize)
   (reset! main/world world-c)

--- a/examples/demos/comportexviz/demos/q_learning_2d.cljs
+++ b/examples/demos/comportexviz/demos/q_learning_2d.cljs
@@ -4,7 +4,7 @@
             [org.nfrac.comportex.util :as util :refer [round abs]]
             [comportexviz.demos.q-learning-1d :refer [q-learning-sub-pane]]
             [comportexviz.main :as main]
-            [comportexviz.viz-canvas :as viz]
+            [comportexviz.helpers :as h]
             [comportexviz.plots-canvas :as plt]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]
@@ -87,14 +87,14 @@
 (defn on-resize
   [_]
   (when-let [el (dom/getElement "comportex-world")]
-    (viz/set-canvas-pixels-from-element-size! el 120)
+    (h/set-canvas-pixels-from-element-size! el 120)
     (swap! trigger-redraw inc)))
 
 (defn signed-str [x] (str (if (neg? x) "" "+") x))
 
 (defn world-pane
   []
-  (when-let [htm (viz/selected-model-step)]
+  (when-let [htm (main/selected-model-step)]
     (let [in-value (:value (first (core/input-seq htm)))
           canvas (dom/getElement "comportex-world")]
       (when canvas
@@ -205,10 +205,10 @@
 
 (defn ^:export init
   []
-  (reagent/render (main/comportexviz-app model-tab world-pane)
+  (reagent/render [main/comportexviz-app model-tab world-pane]
                   (dom/getElement "comportexviz-app"))
   (.addEventListener js/window "resize" on-resize)
-  (swap! viz/viz-options assoc-in [:drawing :display-mode] :two-d)
+  (swap! main/viz-options assoc-in [:drawing :display-mode] :two-d)
   (set-model!)
   (reset! main/world world-c)
   (feed-world!))

--- a/examples/demos/comportexviz/demos/sensorimotor_1d.cljs
+++ b/examples/demos/comportexviz/demos/sensorimotor_1d.cljs
@@ -2,7 +2,7 @@
   (:require [org.nfrac.comportex.demos.sensorimotor-1d :as demo]
             [org.nfrac.comportex.core :as core]
             [comportexviz.main :as main]
-            [comportexviz.viz-canvas :as viz]
+            [comportexviz.helpers :as h]
             [comportexviz.plots-canvas :as plt]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]
@@ -122,12 +122,12 @@
 (defn on-resize
   [_]
   (when-let [el (dom/getElement "comportex-world")]
-    (viz/set-canvas-pixels-from-element-size! el 100)
+    (h/set-canvas-pixels-from-element-size! el 100)
     (swap! trigger-redraw inc)))
 
 (defn world-pane
   []
-  (when-let [htm (viz/selected-model-step)]
+  (when-let [htm (main/selected-model-step)]
     (let [in-value (:value (first (core/input-seq htm)))
           canvas (dom/getElement "comportex-world")]
       (when canvas
@@ -219,7 +219,7 @@
 
 (defn ^:export init
   []
-  (reagent/render (main/comportexviz-app model-tab world-pane)
+  (reagent/render [main/comportexviz-app model-tab world-pane]
                   (dom/getElement "comportexviz-app"))
   (.addEventListener js/window "resize" on-resize)
   (reset! main/world world-c)

--- a/examples/demos/comportexviz/demos/simple_sentences.cljs
+++ b/examples/demos/comportexviz/demos/simple_sentences.cljs
@@ -35,7 +35,7 @@
   []
   (let [show-predictions (atom false)]
     (fn []
-      (when-let [htm (viz/selected-model-step)]
+      (when-let [htm (main/selected-model-step)]
         (let [in-value (:value (first (core/input-seq htm)))]
           [:div
            [:p.muted [:small "Input on selected timestep."]]
@@ -130,7 +130,7 @@
 
 (defn ^:export init
   []
-  (reagent/render (main/comportexviz-app model-tab world-pane)
+  (reagent/render [main/comportexviz-app model-tab world-pane]
                   (dom/getElement "comportexviz-app"))
   (reset! main/world world-c)
   (set-model!)

--- a/src/comportexviz/helpers.cljs
+++ b/src/comportexviz/helpers.cljs
@@ -1,6 +1,7 @@
 (ns comportexviz.helpers
   (:require [goog.dom]
             [goog.dom.classes]
+            [goog.style :as style]
             [org.nfrac.comportex.core :as core]
             [org.nfrac.comportex.protocols :as p]
             [org.nfrac.comportex.util :refer [round]]))
@@ -60,3 +61,12 @@
         pr-votes (core/predicted-bit-votes rgn)
         predictions (p/decode (:encoder inp) pr-votes n-predictions)]
     (predictions-table predictions)))
+
+(defn set-canvas-pixels-from-element-size!
+  [el min-px-width]
+  (let [size-px (style/getSize el)
+        width-px (-> (.-width size-px)
+                     (max min-px-width))
+        height-px (.-height size-px)]
+    (set! (.-width el) width-px)
+    (set! (.-height el) height-px)))

--- a/src/comportexviz/main.cljs
+++ b/src/comportexviz/main.cljs
@@ -5,7 +5,7 @@
             [comportexviz.viz-canvas :as viz]
             [reagent.core :as reagent :refer [atom]]
             [cljs.core.async :as async :refer [chan put! <!]])
-  (:require-macros [cljs.core.async.macros :refer [go]]))
+  (:require-macros [cljs.core.async.macros :refer [go go-loop]]))
 
 (enable-console-print!)
 
@@ -15,7 +15,7 @@
     (async/tap mult c)
     c))
 
-;;; ## Data
+;;; ## Simulation data
 
 (def model (atom nil))
 (def world (atom (chan)))
@@ -26,6 +26,14 @@
 (def main-options
   (atom {:sim-go? false
          :sim-step-ms 200}))
+
+;;; ## Viz data
+
+(def model-steps (atom []))
+(def selection (atom viz/blank-selection))
+(def viz-options (atom viz/default-viz-options))
+(def into-viz (chan))
+(def from-viz (chan))
 
 ;;; ## Simulation
 
@@ -56,38 +64,39 @@
                         (not (:sim-go? old)))
                (run-sim))))
 
-(def controls
-  {:step-backward viz/step-backward!
-   :step-forward #(viz/step-forward! sim-step!)
-   :column-up #(swap! viz/selection update-in [:col]
-                      (fn [x] (when (and x (pos? x)) (dec x))))
-   :column-down #(swap! viz/selection update-in [:col]
-                        (fn [x] (if x (inc x) 0)))
-   :scroll-up #(viz/scroll! false)
-   :scroll-down #(viz/scroll! true)
-   :toggle-run #(swap! main-options update-in [:sim-go?] not)
-   })
-
 ;;; ## Entry point
 
-(defn main-pane [world-pane]
-  (fn []
-    [:div
-     [viz/viz-timeline]
-     [:div.row
-      [:div.col-sm-3.col-lg-2
-       [world-pane]]
-      [:div.col-sm-9.col-lg-10
-       [viz/viz-canvas {:tabIndex 1} controls]]]]))
+(go-loop []
+  (when-let [command (<! from-viz)]
+    (case command
+      :toggle-run (swap! main-options update-in [:sim-go?] not)
+      :sim-step (sim-step!))
+    (recur)))
+
+(viz/record-simulation! (tap-c steps-mult) model-steps viz-options)
+
+(defn main-pane [world-pane model-steps selection viz-options into-viz from-viz]
+  [:div
+   [viz/viz-timeline model-steps selection viz-options]
+   [:div.row
+    [:div.col-sm-3.col-lg-2
+     [world-pane]]
+    [:div.col-sm-9.col-lg-10
+     [viz/viz-canvas {:tabIndex 1} model-steps selection viz-options
+      into-viz from-viz]]]])
 
 (defn comportexviz-app
   [model-tab world-pane]
-  (viz/init! (tap-c steps-mult))
-  (cui/comportexviz-app model-tab (main-pane world-pane) model main-options
-                        viz/viz-options viz/selection viz/model-steps controls
-                        viz/state-colors))
+  (let [m (fn [] [main-pane world-pane model-steps selection viz-options
+                  into-viz from-viz])]
+    (cui/comportexviz-app model-tab m model main-options viz-options
+                          selection model-steps viz/state-colors into-viz)))
 
 (defn set-model!
   [x]
   (reset! model x)
-  (viz/oh-look-the-model-changed! x))
+  (put! into-viz [:on-model-changed x]))
+
+(defn selected-model-step
+  []
+  (viz/selected-model-step model-steps selection))


### PR DESCRIPTION
Switch to a channel model for commands so that they can be sent to a particular canvas.

comportexviz.main still uses global atoms. Other consumers will use viz-canvas directly, providing their own atoms to viz-canvas.

Minor fix: use hiccup vectors, not function calls, for the `reagent/render`s so that component fns can return functions without causing confusing bugs with parameters.