### PR TITLE
Access models via "proxies", init simulations in the per-page code

### DIFF
--- a/examples/demos/comportexviz/demos/letters.cljs
+++ b/examples/demos/comportexviz/demos/letters.cljs
@@ -4,7 +4,7 @@
             [org.nfrac.comportex.util :as util]
             [comportexviz.main :as main]
             [comportexviz.helpers :as helpers]
-            [comportexviz.viz-canvas :as viz]
+            [comportexviz.simulation.browser :as simulation]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]
             [goog.dom :as dom]
@@ -22,7 +22,13 @@
   (async/chan world-buffer
               (map (util/keep-history-middleware 300 :value :history))))
 
-(add-watch main/model ::count-world-buffer
+(def into-sim
+  (atom nil))
+
+(def model
+  (atom nil))
+
+(add-watch model ::count-world-buffer
            (fn [_ _ _ _]
              (swap! config assoc :world-buffer-count (count world-buffer))))
 
@@ -67,13 +73,20 @@ Chifung has a friend."))
 
 (defn set-model!
   []
+  (helpers/close-and-reset! into-sim (async/chan))
+  (helpers/close-and-reset! main/steps-c (async/chan))
+
   (let [n-regions (:n-regions @config)
         encoder (case (:encoder @config)
                   :block demo/block-encoder
                   :random demo/random-encoder)]
     (with-ui-loading-message
-      (main/set-model!
-       (demo/n-region-model n-regions demo/spec encoder)))))
+      (reset! model (demo/n-region-model n-regions demo/spec encoder))
+      (simulation/simulate-onto-chan! @main/steps-c
+                                      model
+                                      world-c
+                                      main/sim-options
+                                      @into-sim))))
 
 (defn immediate-key-down!
   [e]
@@ -150,8 +163,7 @@ Chifung has a friend."))
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane]
+  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
                   (dom/getElement "comportexviz-app"))
-  (reset! main/world world-c)
   (set-model!)
-  (swap! main/main-options assoc :sim-go? true))
+  (swap! main/sim-options assoc :go? true))

--- a/examples/demos/comportexviz/demos/q_learning_2d.cljs
+++ b/examples/demos/comportexviz/demos/q_learning_2d.cljs
@@ -4,8 +4,9 @@
             [org.nfrac.comportex.util :as util :refer [round abs]]
             [comportexviz.demos.q-learning-1d :refer [q-learning-sub-pane]]
             [comportexviz.main :as main]
-            [comportexviz.helpers :refer [resizing-canvas]]
+            [comportexviz.helpers :as helpers :refer [resizing-canvas tap-c]]
             [comportexviz.plots-canvas :as plt]
+            [comportexviz.simulation.browser :as simulation]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]
@@ -21,12 +22,23 @@
 (def world-c
   (async/chan (async/buffer 1)))
 
+(def into-sim
+  (atom nil))
+
+(def model
+  (atom nil))
+
+(def raw-models-c
+  (async/chan))
+(def raw-models-mult
+  (async/mult raw-models-c))
+
 (defn feed-world!
   "Feed the world input channel continuously, selecting actions from
    state of model itself."
   []
-  (let [step-c (main/tap-c main/steps-mult)]
-    (demo/feed-world-c-with-actions! step-c world-c main/model)))
+  (let [step-c (tap-c raw-models-mult)]
+    (demo/feed-world-c-with-actions! step-c world-c model)))
 
 (defn draw-world
   [ctx in-value htm]
@@ -127,10 +139,20 @@
 
 (defn set-model!
   []
-  (let [n-regions (:n-regions @config)]
-    (with-ui-loading-message
-      (main/set-model!
-       (demo/make-model)))))
+  (helpers/close-and-reset! into-sim (async/chan))
+  (helpers/close-and-reset! main/steps-c
+                            (async/chan
+                             100 (map simulation/browser-instance-proxy)))
+
+  (async/tap raw-models-mult @main/steps-c)
+
+  (with-ui-loading-message
+    (reset! model (demo/make-model))
+    (simulation/simulate-raw-models-onto-chan! raw-models-c
+                                               model
+                                               world-c
+                                               main/sim-options
+                                               @into-sim)))
 
 (def config-template
   [:div.form-horizontal
@@ -193,9 +215,8 @@
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane]
+  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
                   (dom/getElement "comportexviz-app"))
   (swap! main/viz-options assoc-in [:drawing :display-mode] :two-d)
   (set-model!)
-  (reset! main/world world-c)
   (feed-world!))

--- a/src/comportexviz/plots.cljs
+++ b/src/comportexviz/plots.cljs
@@ -132,10 +132,10 @@
         agg-freqs-ts (aggregating-ts step-freqs 200)]
     (add-watch steps [:calc-freqs region-key layer-id] ;; unique key per layer
                (fn [_ _ _ v]
-                 (let [htm (first v)
-                       freqs (-> htm :regions region-key
-                                 (core/column-state-freqs layer-id))]
-                   (reset! step-freqs freqs))))
+                 (when-let [htm (first v)]
+                   (let [freqs (-> htm :regions region-key
+                                   (core/column-state-freqs layer-id))]
+                     (reset! step-freqs freqs)))))
     (fn [_ _ _ _]
       (let [el-id (str "comportexviz-tsplot-" (name region-key) (name layer-id))
             el (dom/getElement el-id)]

--- a/src/comportexviz/proxies.cljs
+++ b/src/comportexviz/proxies.cljs
@@ -1,0 +1,69 @@
+(ns comportexviz.proxies
+  (:require [cljs.core.async :as async :refer [chan put! <!]]
+            [comportexviz.helpers :as helpers]
+            [org.nfrac.comportex.protocols :as p])
+  (:require-macros [cljs.core.async.macros :refer [go]]))
+
+;; Contents:
+;; - A proxy interface for fetching data from remote data structures
+;; - The proxy types, and the functions that create/populate them
+;;
+;;
+;; Stage 1:
+;; Just prefetch the entire model so that rendering can stay synchronous.
+;;
+;; TODO:
+;; Make prefetching more selective, rendering more asynchronous.
+
+(defprotocol PHasRemoteResources
+  (release! [_]))
+
+(defprotocol PProxy
+  (fetch [_ route]))
+
+(defn- get-method-result
+  [m method & args]
+  (let [{:keys [method-results]} m
+        lookup (into [method] args)]
+    (assert (contains? method-results lookup))
+    (get method-results lookup)))
+
+;;; ## layer
+
+;; TODO
+
+;;; ## model
+
+(defrecord ModelProxy [original-proxy]
+  PHasRemoteResources
+  (release! [_]
+    (release! original-proxy))
+
+  PProxy
+  (fetch [_ route]
+    (fetch original-proxy route))
+
+  p/PTemporal
+  (timestep [this]
+    (get-method-result this :timestep)))
+
+(def model-prefetch
+  {:values [:ff-deps :fb-deps :strata :inputs :regions :run-start]
+   :methods [[:timestep]]})
+
+(def model-transforms
+  {:f map->ModelProxy})
+
+(defn model-proxy
+  [proxy]
+  (let [out (chan)]
+    (go
+      (put! out
+            (-> (<! (fetch proxy model-prefetch))
+                (assoc :original-proxy proxy)
+                (helpers/update-routed model-transforms
+                                       (fn [m r]
+                                         (if-let [f (:f r)]
+                                           (f m)
+                                           m))))))
+    out))

--- a/src/comportexviz/simulation/browser.cljs
+++ b/src/comportexviz/simulation/browser.cljs
@@ -1,0 +1,35 @@
+(ns comportexviz.simulation.browser
+  (:require [cljs.core.async :as async :refer [chan put!]]
+            [comportexviz.proxies :as proxy]
+            [comportexviz.simulation.common :as common]))
+
+(defn browser-instance-proxy
+  [m]
+  (reify
+    proxy/PHasRemoteResources
+    (release! [_] nil)
+
+    proxy/PProxy
+    (fetch [_ route]
+      (let [c (chan)]
+        (put! c (common/extract-data m route))
+        c))))
+
+(defn simulate-raw-models-onto-chan!
+  [steps-c model world-c options commands-c]
+  (let [model-atom (if (satisfies? IDeref model)
+                     model
+                     (atom model))
+        sim-closed? (atom false)]
+    (common/handle-commands commands-c model-atom sim-closed?)
+    (common/simulation-loop model-atom world-c steps-c options sim-closed?))
+  nil)
+
+;; To end the simulation, close `world-c` and/or `commands-c`. If only one is
+;; closed, the simulation may consume another value from the other before
+;; closing.
+(defn simulate-onto-chan!
+  [steps-c model world-c options commands-c]
+  (let [c (chan)]
+    (async/pipeline 1 steps-c (map browser-instance-proxy) c)
+    (simulate-raw-models-onto-chan! c model world-c options commands-c)))

--- a/src/comportexviz/simulation/common.cljs
+++ b/src/comportexviz/simulation/common.cljs
@@ -1,0 +1,72 @@
+(ns comportexviz.simulation.common
+  (:require [cljs.core.async :as async :refer [chan put! <!]]
+            [comportexviz.helpers :as helpers]
+            [org.nfrac.comportex.protocols :as p])
+  (:require-macros [cljs.core.async.macros :refer [go go-loop]]))
+
+;;; Shared code for various servers
+
+(def whitelisted
+  {:timestep p/timestep})
+
+(defn- extract-data [m route]
+  (helpers/update-routed
+   m route
+   (fn [m route]
+     (let [{:keys [values methods]} route]
+       (-> (select-keys m values)
+           (assoc :method-results
+                  (zipmap methods
+                          (->> methods
+                               (map (fn [[method & args]]
+                                      (let [f (whitelisted method)]
+                                        (assert f)
+                                        (apply f m args))))))))))))
+
+(defn- sim-step! [model in-value out]
+  (->> (swap! model p/htm-step in-value)
+       (put! out)))
+
+(defn now [] (.getTime (js/Date.)))
+
+(defn should-go?! [options]
+  (let [{:keys [go? force-n-steps step-ms]} @options]
+    (cond
+      go? step-ms
+      (pos? force-n-steps) (do
+                             (swap! options update :force-n-steps dec)
+                             0)
+      :else false)))
+
+(defn- simulation-loop [model world out options sim-closed?]
+  (go
+    (swap! model assoc
+           :run-start {:time (now)
+                       :timestep (p/timestep @model)})
+
+    (if (loop []
+          (when (not @sim-closed?)
+            (if-let [t (should-go?! options)]
+              (when-let [in-value (<! world)]
+                (sim-step! model in-value out)
+                (<! (async/timeout t))
+                (recur))
+              true)))
+      (add-watch options :run-sim
+                 (fn [_ _ _ _]
+                   (remove-watch options :run-sim)
+                   (simulation-loop model world out options sim-closed?)))
+      (reset! sim-closed? true))))
+
+(defn handle-commands [commands model sim-closed?]
+  (go-loop []
+    (when-not @sim-closed?
+      (when-let [[command & xs] (<! commands)]
+        (do (case command
+              :set-spec (let [[path v] xs]
+                          (swap! model assoc-in path v))
+              :restart (let [[result] xs]
+                         (swap! model p/restart)
+                         (put! result :done)))
+            (recur))))
+    (reset! sim-closed? true)))

--- a/src/comportexviz/simulation/remote.cljs
+++ b/src/comportexviz/simulation/remote.cljs
@@ -1,0 +1,6 @@
+(ns comportexviz.simulation.remote)
+
+(defn simulate-onto-chan! [steps-c options commands]
+  ;; Keep the options in sync with the server. The server or the client may
+  ;; change the options.
+  :TODO)


### PR DESCRIPTION
This is initial work to enable visualizing external models without
having to dump the entire model into the browser.

In the current code it still requests the whole model via these
proxies. Subsequent changes will delay fetching of portions of the
model (e.g. synapse graphs), making parts of the rendering
asynchronous.

This change also:
 - Made the :on-model-changed notification less fragile.
 - Made the viz-canvas component stop eating commands after unmount.
   Otherwise it becomes a big red herring when unexpected remounts
   happen.