### PR TITLE
Visualize Comportex while it runs on the JVM

### DIFF
--- a/examples/cortical_io/comportexviz/cortical_io_demo.cljs
+++ b/examples/cortical_io/comportexviz/cortical_io_demo.cljs
@@ -10,7 +10,7 @@
             [comportexviz.main :as main]
             [comportexviz.helpers :as helpers]
             [comportexviz.server.browser :as server]
-            [comportexviz.server.simulation :refer [default-sim-options]]
+            [comportexviz.util :as utilv]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]
             [goog.dom :as dom]
@@ -80,10 +80,6 @@ fox eat something.
 (def world-c
   (async/chan world-buffer
               (map (util/keep-history-middleware 100 :word :history))))
-
-(def sim-options
-  (atom (assoc default-sim-options
-               :go? true)))
 
 (def into-sim
   (atom nil))
@@ -228,8 +224,9 @@ fox eat something.
 
 (defn set-model!
   []
-  (helpers/close-and-reset! into-sim (async/chan))
-  (helpers/close-and-reset! main/into-journal (async/chan))
+  (utilv/close-and-reset! into-sim (async/chan))
+  (utilv/close-and-reset! main/into-journal (async/chan))
+  (put! @into-sim [:run])
 
   (let [n-regions (:n-regions @config)
         spec (case (:spec-choice @config)
@@ -253,8 +250,7 @@ fox eat something.
       (server/init model
                    world-c
                    @main/into-journal
-                   @into-sim
-                   sim-options)
+                   @into-sim)
       (swap! config assoc :have-model? true))))
 
 (def config-template
@@ -363,7 +359,6 @@ fox eat something.
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane sim-options
-                   into-sim]
+  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
                   (dom/getElement "comportexviz-app"))
   (swap! main/viz-options assoc-in [:drawing :display-mode] :two-d))

--- a/examples/demos/comportexviz/demos/coordinates_2d.cljs
+++ b/examples/demos/comportexviz/demos/coordinates_2d.cljs
@@ -6,7 +6,7 @@
             [comportexviz.helpers :as helpers :refer [resizing-canvas]]
             [comportexviz.plots-canvas :as plt]
             [comportexviz.server.browser :as server]
-            [comportexviz.server.simulation :refer [default-sim-options]]
+            [comportexviz.util :as utilv]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]
@@ -23,9 +23,6 @@
               (map (util/keep-history-middleware
                     50 #(select-keys % [:x :y :vx :vy])
                     :history))))
-
-(def sim-options
-  (atom default-sim-options))
 
 (def into-sim
   (atom nil))
@@ -131,14 +128,13 @@
 
 (defn set-model!
   []
-  (helpers/close-and-reset! into-sim (async/chan))
-  (helpers/close-and-reset! main/into-journal (async/chan))
+  (utilv/close-and-reset! into-sim (async/chan))
+  (utilv/close-and-reset! main/into-journal (async/chan))
   (with-ui-loading-message
     (server/init (demo/n-region-model (:n-regions @config))
                  world-c
                  @main/into-journal
-                 @into-sim
-                 sim-options)))
+                 @into-sim)))
 
 (def config-template
   [:div.form-horizontal
@@ -192,8 +188,7 @@
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane sim-options
-                   into-sim]
+  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
                   (dom/getElement "comportexviz-app"))
   (swap! main/viz-options assoc-in [:drawing :display-mode] :two-d)
   (feed-world!)

--- a/examples/demos/comportexviz/demos/fixed_seqs.cljs
+++ b/examples/demos/comportexviz/demos/fixed_seqs.cljs
@@ -9,12 +9,12 @@
             [comportexviz.helpers :as helpers :refer [resizing-canvas]]
             [comportexviz.plots-canvas :as plt]
             [comportexviz.server.browser :as server]
-            [comportexviz.server.simulation :refer [default-sim-options]]
+            [comportexviz.util :as utilv]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]
             [goog.dom :as dom]
-            [cljs.core.async :as async])
+            [cljs.core.async :as async :refer [put!]])
   (:require-macros [comportexviz.macros :refer [with-ui-loading-message]]))
 
 (def config
@@ -23,10 +23,6 @@
 
 (def world-c
   (atom nil))
-
-(def sim-options
-  (atom (assoc default-sim-options
-               :go? true)))
 
 (def into-sim
   (atom nil))
@@ -137,20 +133,20 @@
 
 (defn set-model!
   []
-  (helpers/close-and-reset! main/into-journal (async/chan))
-  (helpers/close-and-reset! into-sim (async/chan))
+  (utilv/close-and-reset! main/into-journal (async/chan))
+  (utilv/close-and-reset! into-sim (async/chan))
+  (put! @into-sim [:run])
 
   (let [{:keys [input-stream n-regions]} @config
         {:keys [model-fn world-fn xy?]} (model-info input-stream)]
-    (helpers/close-and-reset! world-c (make-world-chan world-fn input-stream))
+    (utilv/close-and-reset! world-c (make-world-chan world-fn input-stream))
     (swap! main/viz-options assoc-in [:drawing :display-mode]
            (if (= input-stream :isolated-2d) :two-d :one-d))
     (with-ui-loading-message
       (server/init (model-fn n-regions)
                    @world-c
                    @main/into-journal
-                   @into-sim
-                   sim-options))))
+                   @into-sim))))
 
 (def config-template
   [:div.form-horizontal
@@ -232,6 +228,5 @@
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane sim-options
-                   into-sim]
+  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
                   (dom/getElement "comportexviz-app")))

--- a/examples/demos/comportexviz/demos/letters.cljs
+++ b/examples/demos/comportexviz/demos/letters.cljs
@@ -5,7 +5,7 @@
             [comportexviz.main :as main]
             [comportexviz.helpers :as helpers]
             [comportexviz.server.browser :as server]
-            [comportexviz.server.simulation :refer [default-sim-options]]
+            [comportexviz.util :as utilv]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]
             [goog.dom :as dom]
@@ -23,10 +23,6 @@
 (def world-c
   (async/chan world-buffer
               (map (util/keep-history-middleware 300 :value :history))))
-
-(def sim-options
-  (atom (assoc default-sim-options
-               :go? true)))
 
 (def into-sim
   (atom nil))
@@ -88,8 +84,8 @@ Chifung has a friend."))
 
 (defn set-model!
   []
-  (helpers/close-and-reset! into-sim (async/chan))
-  (helpers/close-and-reset! main/into-journal (async/chan))
+  (utilv/close-and-reset! into-sim (async/chan))
+  (utilv/close-and-reset! main/into-journal (async/chan))
 
   (let [n-regions (:n-regions @config)
         encoder (case (:encoder @config)
@@ -100,8 +96,7 @@ Chifung has a friend."))
       (server/init model
                    world-c
                    @main/into-journal
-                   @into-sim
-                   sim-options))))
+                   @into-sim))))
 
 (defn immediate-key-down!
   [e]
@@ -178,7 +173,6 @@ Chifung has a friend."))
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane sim-options
-                   into-sim]
+  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
                   (dom/getElement "comportexviz-app"))
   (set-model!))

--- a/examples/demos/comportexviz/demos/q_learning_1d.cljs
+++ b/examples/demos/comportexviz/demos/q_learning_1d.cljs
@@ -6,7 +6,7 @@
             [comportexviz.helpers :as helpers :refer [resizing-canvas]]
             [comportexviz.plots-canvas :as plt]
             [comportexviz.server.browser :as server]
-            [comportexviz.server.simulation :refer [default-sim-options]]
+            [comportexviz.util :as utilv]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]
@@ -23,9 +23,6 @@
 (def world-c
   (async/chan (async/buffer 1)
               (map (util/frequencies-middleware :x :freqs))))
-
-(def sim-options
-  (atom default-sim-options))
 
 (def into-sim
   (atom nil))
@@ -219,8 +216,8 @@
 
 (defn set-model!
   []
-  (helpers/close-and-reset! into-sim (async/chan))
-  (helpers/close-and-reset! main/into-journal (async/chan))
+  (utilv/close-and-reset! into-sim (async/chan))
+  (utilv/close-and-reset! main/into-journal (async/chan))
 
   (with-ui-loading-message
     (reset! model (demo/make-model))
@@ -228,7 +225,6 @@
                  world-c
                  @main/into-journal
                  @into-sim
-                 sim-options
                  raw-models-c)))
 
 (def config-template
@@ -290,8 +286,7 @@
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane sim-options
-                   into-sim]
+  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
                   (dom/getElement "comportexviz-app"))
   (set-model!)
   (feed-world!))

--- a/examples/demos/comportexviz/demos/q_learning_2d.cljs
+++ b/examples/demos/comportexviz/demos/q_learning_2d.cljs
@@ -4,10 +4,10 @@
             [org.nfrac.comportex.util :as util :refer [round abs]]
             [comportexviz.demos.q-learning-1d :refer [q-learning-sub-pane]]
             [comportexviz.main :as main]
-            [comportexviz.helpers :as helpers :refer [resizing-canvas tap-c]]
+            [comportexviz.helpers :as helpers :refer [resizing-canvas]]
             [comportexviz.plots-canvas :as plt]
             [comportexviz.server.browser :as server]
-            [comportexviz.server.simulation :refer [default-sim-options]]
+            [comportexviz.util :as utilv]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]
@@ -23,9 +23,6 @@
 
 (def world-c
   (async/chan (async/buffer 1)))
-
-(def sim-options
-  (atom default-sim-options))
 
 (def into-sim
   (atom nil))
@@ -151,8 +148,8 @@
 
 (defn set-model!
   []
-  (helpers/close-and-reset! into-sim (async/chan))
-  (helpers/close-and-reset! main/into-journal (async/chan))
+  (utilv/close-and-reset! into-sim (async/chan))
+  (utilv/close-and-reset! main/into-journal (async/chan))
 
   (with-ui-loading-message
     (reset! model (demo/make-model))
@@ -160,7 +157,6 @@
                  world-c
                  @main/into-journal
                  @into-sim
-                 sim-options
                  raw-models-c)))
 
 (def config-template
@@ -224,8 +220,7 @@
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane sim-options
-                   into-sim]
+  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
                   (dom/getElement "comportexviz-app"))
   (swap! main/viz-options assoc-in [:drawing :display-mode] :two-d)
   (set-model!)

--- a/examples/demos/comportexviz/demos/runner.cljs
+++ b/examples/demos/comportexviz/demos/runner.cljs
@@ -1,0 +1,26 @@
+(ns comportexviz.demos.runner
+  (:require [comportexviz.main :as main]
+            [comportexviz.server.remote :as server]
+            [reagent.core :as reagent :refer [atom]]
+            [goog.dom :as dom]
+            [cljs.core.async :as async])
+  (:require-macros [comportexviz.macros :refer [with-ui-loading-message]]))
+
+(defn world-pane
+  [])
+
+(defn model-tab
+  [])
+
+(defn ^:export init
+  []
+  (reset! main/into-journal (async/chan))
+
+  (let [into-sim (atom (async/chan))]
+    (server/init (str "ws://" js/location.host "/ws/")
+                 @main/into-journal
+                 @into-sim
+                 main/channel-proxies)
+
+    (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
+                    (dom/getElement "comportexviz-app"))))

--- a/examples/demos/comportexviz/demos/second_level_motor.cljs
+++ b/examples/demos/comportexviz/demos/second_level_motor.cljs
@@ -2,11 +2,11 @@
   (:require [org.nfrac.comportex.demos.second-level-motor :as demo]
             [org.nfrac.comportex.core :as core]
             [comportexviz.main :as main]
-            [comportexviz.helpers :as helpers :refer [resizing-canvas tap-c]]
+            [comportexviz.helpers :as helpers :refer [resizing-canvas]]
             [comportexviz.plots-canvas :as plt]
             [comportexviz.demos.sensorimotor-1d :refer [draw-eye]]
             [comportexviz.server.browser :as server]
-            [comportexviz.server.simulation :refer [default-sim-options]]
+            [comportexviz.util :as utilv]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]
@@ -22,9 +22,6 @@
 (def world-c (async/chan))
 
 (def control-c (async/chan))
-
-(def sim-options
-  (atom default-sim-options))
 
 (def into-sim (atom nil))
 
@@ -144,8 +141,8 @@
 (defn set-model!
   []
   (let [] ;; TODO: config
-    (helpers/close-and-reset! into-sim (async/chan))
-    (helpers/close-and-reset! main/into-journal (async/chan))
+    (utilv/close-and-reset! into-sim (async/chan))
+    (utilv/close-and-reset! main/into-journal (async/chan))
 
     (with-ui-loading-message
       (reset! model (demo/two-region-model))
@@ -153,7 +150,6 @@
                    world-c
                    @main/into-journal
                    @into-sim
-                   sim-options
                    raw-models-c))))
 
 (defn set-text!
@@ -221,8 +217,7 @@
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane sim-options
-                   into-sim]
+  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
                   (dom/getElement "comportexviz-app"))
 
   (set-model!)

--- a/examples/demos/comportexviz/demos/sensorimotor_1d.cljs
+++ b/examples/demos/comportexviz/demos/sensorimotor_1d.cljs
@@ -5,7 +5,7 @@
             [comportexviz.helpers :as helpers :refer [resizing-canvas]]
             [comportexviz.plots-canvas :as plt]
             [comportexviz.server.browser :as server]
-            [comportexviz.server.simulation :refer [default-sim-options]]
+            [comportexviz.util :as utilv]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]
@@ -22,10 +22,6 @@
 
 (def world-buffer (async/buffer 5000))
 (def world-c (async/chan world-buffer))
-
-(def sim-options
-  (atom (assoc default-sim-options
-               :go? true)))
 
 (def into-sim
   (atom nil))
@@ -163,16 +159,15 @@
 
 (defn set-model!
   []
-  (helpers/close-and-reset! into-sim (async/chan))
-  (helpers/close-and-reset! main/into-journal (async/chan))
+  (utilv/close-and-reset! into-sim (async/chan))
+  (utilv/close-and-reset! main/into-journal (async/chan))
 
   (with-ui-loading-message
     (reset! model (demo/n-region-model (:n-regions @config)))
     (server/init model
                  world-c
                  @main/into-journal
-                 @into-sim
-                 sim-options)))
+                 @into-sim)))
 
 (def config-template
   [:div
@@ -228,7 +223,6 @@
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane sim-options
-                   into-sim]
+  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
                   (dom/getElement "comportexviz-app"))
   (set-model!))

--- a/examples/demos/comportexviz/demos/simple_sentences.cljs
+++ b/examples/demos/comportexviz/demos/simple_sentences.cljs
@@ -5,7 +5,7 @@
             [comportexviz.main :as main]
             [comportexviz.helpers :as helpers]
             [comportexviz.server.browser :as server]
-            [comportexviz.server.simulation :refer [default-sim-options]]
+            [comportexviz.util :as utilv]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]
             [goog.dom :as dom]
@@ -25,9 +25,6 @@
 (def world-c
   (async/chan world-buffer
               (map (util/keep-history-middleware 100 :word :history))))
-
-(def sim-options
-  (atom default-sim-options))
 
 (def into-sim
   (atom nil))
@@ -76,8 +73,8 @@
 
 (defn set-model!
   []
-  (helpers/close-and-reset! into-sim (async/chan))
-  (helpers/close-and-reset! main/into-journal (async/chan))
+  (utilv/close-and-reset! into-sim (async/chan))
+  (utilv/close-and-reset! main/into-journal (async/chan))
 
   (let [n-regions (:n-regions @config)
         encoder (case (:encoder @config)
@@ -88,8 +85,7 @@
       (server/init model
                    world-c
                    @main/into-journal
-                   @into-sim
-                   sim-options))))
+                   @into-sim))))
 
 (defn send-text!
   []
@@ -160,7 +156,6 @@
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane sim-options
-                   into-sim]
+  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
                   (dom/getElement "comportexviz-app"))
   (set-model!))

--- a/project.clj
+++ b/project.clj
@@ -9,11 +9,18 @@
                  [org.nfrac/comportex "0.0.9-SNAPSHOT"]
                  [rm-hull/monet "0.2.1"]
                  [reagent "0.5.0"]
-                 [reagent-forms "0.5.1"]]
+                 [reagent-forms "0.5.1"]
+                 [ring/ring-core "1.4.0"]
+                 [compojure "1.4.0"]
+                 [info.sunng/ring-jetty9-adapter "0.8.6"]
+                 [com.cognitect/transit-clj "0.8.271"]
+                 [com.cognitect/transit-cljs "0.8.215"]]
 
   :plugins [[lein-cljsbuild "1.0.6"]
-            [com.cemerick/austin "0.1.6"]]
-  :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}
+            [com.cemerick/austin "0.1.6"]
+            [org.clojure/tools.nrepl "0.2.10"]]
+  :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]
+                 :init-ns comportexviz.launchpad}
 
   :source-paths ["src"]
 

--- a/public/demos/runner.html
+++ b/public/demos/runner.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+  <title>ComportexViz Runner</title>
+
+  <!-- Bootstrap -->
+  <link rel="stylesheet" href="bootstrap-3.3.5-dist/css/bootstrap.min.css">
+
+  <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+  <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+  <!--[if lt IE 9]>
+    <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+    <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+  <![endif]-->
+
+  <link rel="stylesheet" href="../main.css">
+</head>
+<body>
+
+  <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+
+  <div id="comportexviz-app"></div>
+
+  <script type="text/javascript" src="out/goog/base.js"></script>
+  <script type="text/javascript" src="out/comportexviz.js"></script>
+  <script type="text/javascript">goog.require("comportexviz.demos.runner");</script>
+  <script type="text/javascript">
+    comportexviz.demos.runner.init();
+  </script>
+</body>
+</html>

--- a/src/comportexviz/details.cljc
+++ b/src/comportexviz/details.cljc
@@ -3,6 +3,11 @@
             [org.nfrac.comportex.core :as core]
             [org.nfrac.comportex.protocols :as p]))
 
+(defn to-fixed
+  [n digits]
+  #?(:cljs (.toFixed n digits)
+     :clj (format (str "%." digits "f") n)))
+
 (defn detail-text
   [htm
    prior-htm
@@ -71,7 +76,7 @@
               (for [[id p] (sort syns)]
                 (str "  " id
                      (if (>= p ff-pcon) " :=> " " :.: ")
-                     (.toFixed p 2)
+                     (to-fixed p 2)
                      (if (contains? sig-bits id) " S")
                      (if (contains? bits id)
                        (str " A "
@@ -93,7 +98,7 @@
                  (for [[id p] (sort syns)]
                    (str "  " id
                         (if (>= p d-pcon) " :=> " " :.: ")
-                        (.toFixed p 2)
+                        (to-fixed p 2)
                         (if (contains? d-lc-bits id) " L"
                             (if (contains? d-bits id) " A"))))])
               ])

--- a/src/comportexviz/helpers.cljs
+++ b/src/comportexviz/helpers.cljs
@@ -134,21 +134,3 @@
                         [:canvas (assoc props
                                    :width @width-px
                                    :height @height-px)])})))
-(defn tap-c
-  [mult]
-  (let [c (async/chan)]
-    (async/tap mult c)
-    c))
-
-(defn close-and-reset! [chan-atom v]
-  (swap! chan-atom (fn [c]
-                     (when c
-                       (async/close! c))
-                     v)))
-
-(defn index-of
-  [coll pred]
-  (first (->> coll
-              (keep-indexed (fn [i v]
-                              (when (pred v)
-                                i))))))

--- a/src/comportexviz/launchpad.clj
+++ b/src/comportexviz/launchpad.clj
@@ -1,0 +1,31 @@
+(ns comportexviz.launchpad
+  (:require [clojure.core.async :as async]
+            [comportexviz.server.runner :as runner]))
+
+(def runners (atom {}))
+(def port-choice (atom 24600))
+
+(defn stop
+  [port]
+  (runner/stop (get @runners port))
+  (swap! runners dissoc port))
+
+(defn start-runner
+  ([model inputs]
+   (start-runner model inputs nil))
+  ([model inputs opts]
+   (let [input-c (async/chan)]
+     (async/onto-chan input-c inputs)
+     (start-runner model input-c nil opts)))
+  ([model input-c models-out-c {:keys [port]}]
+   (let [model-atom (if (instance? clojure.lang.Ref model)
+                      model
+                      (atom model))
+         port (or port
+                  (swap! port-choice inc))
+         runner (runner/start model-atom input-c models-out-c {:port port
+                                                               :block? false})]
+     (swap! runners assoc port runner)
+     (println (str "Started server on port " port))
+     (println (str "Navigate to http://localhost:" port
+                   "/demos/runner.html")))))

--- a/src/comportexviz/server/browser.cljs
+++ b/src/comportexviz/server/browser.cljs
@@ -1,13 +1,13 @@
 (ns comportexviz.server.browser
   (:require [cljs.core.async :as async]
-            [comportexviz.helpers :as helpers]
             [comportexviz.server.simulation :as simulation]
-            [comportexviz.server.journal :as journal]))
+            [comportexviz.server.journal :as journal]
+            [comportexviz.util :as utilv]))
 
 (defn init
-  ([model world-c into-journal into-sim sim-options]
-   (init model world-c into-journal into-sim sim-options nil))
-  ([model world-c into-journal into-sim sim-options models-out]
+  ([model world-c into-journal into-sim]
+   (init model world-c into-journal into-sim nil))
+  ([model world-c into-journal into-sim models-out]
    (let [model-atom (if (satisfies? IDeref model)
                       model
                       (atom model))
@@ -15,5 +15,5 @@
          models-mult (async/mult models-in)]
      (when models-out
        (async/tap models-mult models-out))
-     (simulation/start models-in model-atom world-c sim-options into-sim)
-     (journal/init (helpers/tap-c models-mult) into-journal model-atom))))
+     (simulation/start models-in model-atom world-c into-sim)
+     (journal/init (utilv/tap-c models-mult) into-journal model-atom))))

--- a/src/comportexviz/server/channel_proxy.cljc
+++ b/src/comportexviz/server/channel_proxy.cljc
@@ -1,0 +1,105 @@
+(ns comportexviz.server.channel-proxy
+  (:require #?(:clj [clojure.core.async :as async]
+               :cljs [cljs.core.async :as async])
+            #?(:clj
+               [clojure.core.async.impl.protocols :as p]
+               :cljs
+               [cljs.core.async.impl.protocols :as p])
+            [cognitect.transit :as transit])
+  #?(:cljs (:require-macros [cljs.core.async.macros :refer [go go-loop]])))
+
+#?(:cljs
+   (defn future [val]
+     (reify cljs.core/IDeref
+       (-deref [_] val))))
+
+(deftype ImpersonateChannel [fput fclose ftake]
+  p/ReadPort
+  (take! [_ _]
+    (future
+      (ftake)))
+
+  p/WritePort
+  (put! [_ v _]
+    (assert v)
+    (future
+      (fput v)))
+
+  p/Channel
+  (close! [_]
+    (fclose)))
+
+(defprotocol PTargeted
+  (target-id [_]))
+
+(deftype ChannelProxy [target-id ch]
+  p/ReadPort
+  (take! [_ handler]
+    (p/take! ch handler))
+
+  p/WritePort
+  (put! [_ v handler]
+    (p/put! ch v handler))
+
+  p/Channel
+  (close! [_]
+    (p/close! ch))
+
+  PTargeted
+  (target-id [_]
+    target-id))
+
+(def last-target-id (atom 24601))
+
+(defprotocol PChannelProxyFactory
+  (from-chan [_ ch])
+  (from-target [_ target-id]))
+
+(defprotocol PChannelProxyRegistry
+  (register-chan [_ target-id ch]))
+
+(deftype ChannelProxyRegistry [target->proxy]
+  PChannelProxyFactory
+  (from-chan [this ch]
+    (register-chan this (swap! last-target-id inc) ch))
+  (from-target [_ target-id]
+    (get @target->proxy target-id))
+
+  PChannelProxyRegistry
+  (register-chan [_ target-id ch]
+    (let [r (ChannelProxy.
+             target-id
+             (ImpersonateChannel. (fn [v]
+                                    (assert v)
+                                    (async/put! ch v))
+                                  (fn []
+                                    (async/close! ch)
+                                    (swap! target->proxy
+                                           dissoc target-id))
+                                  nil))]
+      (swap! target->proxy assoc target-id r)
+      r)))
+
+(defn registry
+  ([]
+   (ChannelProxyRegistry. (atom {})))
+  ([target->chan]
+   (let [r (ChannelProxyRegistry. (atom {}))]
+     (doseq [[t c] target->chan]
+       (register-chan r t c))
+     r)))
+
+;;; ## Transit helpers
+
+(def channel-proxy-tag "comportexviz.server.channel-proxy.ChannelProxy")
+
+(def write-handler
+  {ChannelProxy (transit/write-handler (fn [_]
+                                         channel-proxy-tag)
+                                       target-id)})
+
+(defn read-handler [fput fclose]
+  {channel-proxy-tag (transit/read-handler #(ImpersonateChannel.
+                                             (partial fput %)
+                                             (partial fclose %)
+                                             nil))})

--- a/src/comportexviz/server/journal.cljc
+++ b/src/comportexviz/server/journal.cljc
@@ -14,6 +14,14 @@
    :timestep (p/timestep model)
    :input-values (->> model core/input-seq (map :value))})
 
+(defn id-missing-response
+  [id steps-offset]
+  (let [offset @steps-offset]
+    (assert (< id offset))
+    (println (str "Can't fetch model " id
+                  ". We've dropped all models below id " offset))
+    {}))
+
 (defn init
   [steps-c commands-c current-model]
   (let [steps-offset (atom 0)
@@ -21,12 +29,16 @@
         keep-steps (atom 0)
         subscriber-c (atom nil)
         find-model (fn [id]
-                     (nth @model-steps (- id @steps-offset) nil))
+                     (when (number? id)
+                       (let [i (- id @steps-offset)]
+                         (when-not (neg? i)
+                           (nth @model-steps i nil)))))
         find-model-pair (fn [id]
-                          (let [i (- id @steps-offset)]
-                            (if (zero? i)
-                              [nil (nth @model-steps i nil)]
-                              (subvec @model-steps (dec i) (inc i)))))]
+                          (when (number? id)
+                            (let [i (- id @steps-offset)]
+                              (cond
+                                (pos? i) (subvec @model-steps (dec i) (inc i))
+                                (zero? i) [nil (nth @model-steps i nil)]))))]
     (go-loop []
       (when-let [model (<! steps-c)]
         (let [model-id (+ @steps-offset (count @model-steps))
@@ -39,70 +51,86 @@
         (recur)))
 
     (go-loop []
-      (when-let [[command & xs :as v] (<! commands-c)]
-        (do
+      (when-let [c (<! commands-c)]
+        (let [[command & xs] c]
           (case command
             :subscribe
             (let [[keep-n-steps steps-c response-c] xs]
               (reset! keep-steps keep-n-steps)
               (reset! subscriber-c steps-c)
-              (put! response-c (data/step-template-data @current-model)))
+              (->> (data/step-template-data @current-model)
+                   (put! response-c)))
 
             :set-keep-steps
             (let [[keep-n-steps] xs]
               (reset! keep-steps keep-n-steps))
 
             :get-inbits-cols
-            (let [[id opts out-c] xs
-                  [prev-htm htm] (find-model-pair id)]
-              (put! out-c (data/inbits-cols-data htm prev-htm opts)))
+            (let [[id opts response-c] xs]
+              (put! response-c
+                    (if-let [[prev-htm htm] (find-model-pair id)]
+                      (data/inbits-cols-data htm prev-htm opts)
+                      (id-missing-response id steps-offset))))
 
             :get-inbits-cols-subset
-            (let [[id opts path->ids out-c] xs]
-              (put! out-c (-> (find-model id)
-                              (data/inbits-cols-data-subset path->ids opts))))
+            (let [[id opts path->ids response-c] xs]
+              (put! response-c
+                    (if-let [htm (find-model id)]
+                      (data/inbits-cols-data-subset htm path->ids opts)
+                      (id-missing-response id steps-offset))))
 
             :get-ff-synapses
-            (let [[sel opts out-c] xs
+            (let [[sel opts response-c] xs
                   id (:model-id sel)
                   to (get-in opts [:ff-synapses :to])]
-              (put! out-c (or (when (or (= to :all)
-                                        (and (= to :selected)
-                                             (:col sel)))
-                                (data/ff-synapses-data (find-model id) sel
-                                                       opts))
-                              {})))
+              (put! response-c
+                    (or (when (or (= to :all)
+                                  (and (= to :selected)
+                                       (:col sel)))
+                          (if-let [htm (find-model id)]
+                            (data/ff-synapses-data (find-model id) sel opts)
+                            (id-missing-response id steps-offset)))
+                        {})))
 
             :get-cell-segments
-            (let [[sel opts out-c] xs
-                  id (:model-id sel)
-                  [prev-htm htm] (find-model-pair id)]
-              (put! out-c (or (when (:col sel)
-                                (data/cell-segments-data htm prev-htm sel opts))
-                              {})))
+            (let [[sel opts response-c] xs
+                  id (:model-id sel)]
+              (put! response-c
+                    (if (:col sel)
+                      (if-let [[prev-htm htm] (find-model-pair id)]
+                        (data/cell-segments-data htm prev-htm sel opts)
+                        (id-missing-response id steps-offset))
+                      {})))
 
             :get-details-text
-            (let [[sel out-c] xs
-                  id (:model-id sel)
-                  [prev-htm htm] (find-model-pair id)]
-              (put! out-c (comportexviz.details/detail-text htm prev-htm sel)))
+            (let [[sel response-c] xs
+                  id (:model-id sel)]
+              (put! response-c
+                    (if-let [[prev-htm htm] (find-model-pair id)]
+                      (comportexviz.details/detail-text htm prev-htm sel)
+                      (id-missing-response id steps-offset))))
 
             :get-model
-            (let [[model-id out-c] xs]
-              (put! out-c (find-model model-id)))
+            (let [[id response-c as-str?] xs]
+              (put! response-c
+                    (if-let [htm (find-model id)]
+                      (cond-> htm
+                        as-str? pr-str)
+                      (id-missing-response id steps-offset))))
 
             :get-column-state-freqs
-            (let [[id region-key layer-id
-                   response-c] xs]
-              (put! response-c (-> (find-model id)
-                                   (get-in [:regions region-key])
-                                   (core/column-state-freqs
-                                    layer-id))))
+            (let [[id region-key layer-id response-c] xs]
+              (put! response-c
+                    (if-let [htm (find-model id)]
+                      (-> (get-in htm [:regions region-key])
+                          (core/column-state-freqs layer-id))
+                      (id-missing-response id steps-offset))))
 
             :get-cell-excitation-data
-            (let [[id region-key layer-id sel-col
-                   response-c] xs
-                   [prev-htm htm] (find-model-pair id)]
-              (put! response-c (data/cell-excitation-data
-                                htm prev-htm region-key layer-id sel-col))))
+            (let [[id region-key layer-id sel-col response-c] xs]
+              (put! response-c
+                    (if-let [[prev-htm htm] (find-model-pair id)]
+                      (data/cell-excitation-data htm prev-htm region-key layer-id
+                                                 sel-col)
+                      (id-missing-response id steps-offset)))))
           (recur))))))

--- a/src/comportexviz/server/remote.cljs
+++ b/src/comportexviz/server/remote.cljs
@@ -1,0 +1,55 @@
+(ns comportexviz.server.remote
+  (:require [cljs.core.async :as async :refer [put! close!]]
+            [clojure.set]
+            [cognitect.transit :as transit]
+            [comportexviz.server.channel-proxy :as channel-proxy]
+            [org.nfrac.comportex.topology :refer [map->OneDTopology
+                                                  map->TwoDTopology]])
+  (:require-macros [cljs.core.async.macros :refer [go go-loop]]))
+
+(def handlers
+  {"org.nfrac.comportex.topology.OneDTopology" map->OneDTopology
+   "org.nfrac.comportex.topology.TwoDTopology" map->TwoDTopology})
+
+(defn transit-str
+  [m]
+  (-> (transit/writer :json {:handlers channel-proxy/write-handler})
+      (transit/write m)))
+
+(defn read-transit-str
+  [s extra-handlers]
+  (-> (transit/reader :json {:handlers (merge handlers
+                                              extra-handlers)})
+      (transit/read s)))
+
+(defn init
+  [ws-url into-journal into-sim channel-proxies]
+  (let [id-max (atom 0)
+        ws (js/WebSocket. ws-url)
+        to-network-c (async/chan) ]
+    (go-loop []
+      (let [msg (<! to-network-c)]
+        (when (not (nil? msg))
+          (.send ws (transit-str msg))
+          (recur))))
+
+    (async/pipeline 10 to-network-c (map (fn [v] [:into-sim :put! v])) into-sim
+                    false)
+    (async/pipeline 10 to-network-c (map (fn [v] [:into-journal :put! v]))
+                    into-journal false)
+
+    (set! (.-onmessage ws)
+          (fn [evt]
+            (let [[target op msg] (read-transit-str
+                                   (.-data evt)
+                                   (channel-proxy/read-handler
+                                    (fn [t v]
+                                      (put! to-network-c
+                                            [t :put! v]))
+                                    (fn [t]
+                                      (put! to-network-c
+                                            [t :close!]))))]
+              (let [ch (channel-proxy/from-target channel-proxies target)]
+                (case op
+                  :put! (put! ch msg)
+                  :close! (close! ch))))))))

--- a/src/comportexviz/server/runner.clj
+++ b/src/comportexviz/server/runner.clj
@@ -1,0 +1,100 @@
+(ns comportexviz.server.runner
+  (:require [clojure.core.async :as async :refer [put! <! go go-loop close!]]
+            [cognitect.transit :as transit]
+            [ring.adapter.jetty9 :as jetty :refer [run-jetty]]
+            [compojure.core :refer [defroutes GET]]
+            [compojure.route :as route]
+            [org.nfrac.comportex.core]
+            [comportexviz.server.channel-proxy :as channel-proxy]
+            [comportexviz.server.simulation :as simulation]
+            [comportexviz.server.journal :as journal]
+            [comportexviz.util :as utilv])
+  (:import [java.io ByteArrayOutputStream ByteArrayInputStream]))
+
+(def write-handlers
+  (transit/record-write-handlers
+   org.nfrac.comportex.topology.OneDTopology
+   org.nfrac.comportex.topology.TwoDTopology))
+
+(defn transit-str
+  [m]
+  (let [out (ByteArrayOutputStream.)
+        writer (transit/writer out :json
+                               {:handlers (merge write-handlers
+                                                 channel-proxy/write-handler)})]
+    (transit/write writer m)
+    (.toString out)))
+
+(defn read-transit-str
+  [text extra-handlers]
+  (let [in (-> text (.getBytes "UTF-8") ByteArrayInputStream.)
+        reader (transit/reader in :json {:handlers extra-handlers})]
+    (transit/read reader)))
+
+(defn ws-handler
+  [channel-proxies]
+  (let [clients (atom {})]
+   {:on-connect
+    (fn [ws]
+      (let [to-network-c (async/chan)]
+        (go-loop []
+          (let [msg (<! to-network-c)]
+            (when (not (nil? msg))
+              (jetty/send! ws msg)
+              (recur))))
+        (swap! clients assoc ws to-network-c)))
+
+    :on-error
+    (fn [ws e] (println e))
+
+    :on-close
+    (fn [ws status-code reason]
+      (swap! clients dissoc ws))
+
+    :on-text
+    (fn [ws text]
+      (let [to-network-c (get @clients ws)
+            [target op msg] (read-transit-str
+                             text
+                             (channel-proxy/read-handler
+                              (fn [t v]
+                                (put! to-network-c (transit-str
+                                                    [t :put! v])))
+                              (fn [t]
+                                (put! to-network-c (transit-str
+                                                    [t :close!])))))]
+        (let [ch (channel-proxy/from-target channel-proxies target)]
+          (case op
+            :put! (put! ch msg)
+            :close! (close! ch)))))
+
+    :on-bytes
+    (fn [ws bytes offset len])}))
+
+(defprotocol PStoppable
+  (stop [_]))
+
+(defn start
+  ([model-atom input-c models-out-c {:keys [port block?]}]
+   (let [into-journal (async/chan)
+         into-sim (async/chan)
+         models-in (async/chan)
+         models-mult (async/mult models-in)
+
+         channel-proxies (channel-proxy/registry {:into-sim into-sim
+                                                  :into-journal into-journal})
+         server (run-jetty (route/files "/")
+                           {:port port
+                            :websockets {"/ws" (ws-handler channel-proxies)}
+                            :join? block?})]
+     (when models-out-c
+       (async/tap models-mult models-out-c))
+     (simulation/start models-in model-atom input-c into-sim)
+     (journal/init (utilv/tap-c models-mult) into-journal model-atom)
+     (reify
+       PStoppable
+       (stop [_]
+         (.stop server)
+         (close! into-journal)
+         (close! into-sim)
+         (close! models-in))))))

--- a/src/comportexviz/server/simulation.cljc
+++ b/src/comportexviz/server/simulation.cljc
@@ -7,11 +7,6 @@
             [org.nfrac.comportex.util :as util])
   #?(:cljs (:require-macros [cljs.core.async.macros :refer [go go-loop]])))
 
-(def default-sim-options
-  {:go? false
-   :step-ms 20
-   :force-n-steps 0})
-
 (defn- sim-step! [model in-value out]
   (->> (swap! model p/htm-step in-value)
        (put! out)))
@@ -41,26 +36,46 @@
                    (simulation-loop model world out options sim-closed?)))
       (reset! sim-closed? true))))
 
-(defn handle-commands [commands model sim-closed?]
-  (go-loop []
-    (if-not @sim-closed?
-      (when-let [[command & xs] (<! commands)]
-        (case command
-          :set-spec (let [[path v] xs]
-                      (swap! model assoc-in path v))
-          :restart (let [[result] xs]
-                     (swap! model p/restart)
-                     (put! result :done)))
-        (recur))
-      (reset! sim-closed? true))))
+(defn handle-commands [commands model options sim-closed?]
+  (let [subscribers (atom #{})]
+    (add-watch options ::push-to-subscribers
+               (fn [_ _ oldv newv]
+                 (let [g (:go? newv)]
+                   (when (not= g (:go? oldv))
+                     (let [m [g]]
+                       (doseq [s @subscribers]
+                         (put! s m)))))))
+    (go-loop []
+      (if-not @sim-closed?
+        (when-let [c (<! commands)]
+          (let [[command & xs] c]
+            (case command
+              :step (swap! options update :force-n-steps inc)
+              :set-spec (let [[path v] xs]
+                          (swap! model assoc-in path v))
+              :restart (let [[result response-c] xs]
+                         (swap! model p/restart)
+                         (put! response-c :done))
+              :toggle (swap! options update :go? not)
+              :pause (swap! options assoc :go? false)
+              :run (swap! options assoc :go? true)
+              :set-step-ms (let [[t] xs]
+                             (swap! options assoc :step-ms t))
+              :subscribe-to-status (let [[ch] xs]
+                                     (swap! subscribers conj ch))))
+          (recur))
+        (reset! sim-closed? true)))))
 
 ;; To end the simulation, close `world-c` and/or `commands-c`. If only one is
 ;; closed, the simulation may consume another value from the other before
 ;; closing.
 (defn start
-  [steps-c model-atom world-c options commands-c]
-  (let [sim-closed? (atom false)]
+  [steps-c model-atom world-c commands-c]
+  (let [options (atom {:go? false
+                       :step-ms 20
+                       :force-n-steps 0})
+        sim-closed? (atom false)]
     (when commands-c
-      (handle-commands commands-c model-atom sim-closed?))
+      (handle-commands commands-c model-atom options sim-closed?))
     (simulation-loop model-atom world-c steps-c options sim-closed?))
   nil)

--- a/src/comportexviz/util.cljc
+++ b/src/comportexviz/util.cljc
@@ -1,0 +1,22 @@
+(ns comportexviz.util
+  (:require #?(:clj [clojure.core.async :as async]
+               :cljs [cljs.core.async :as async])))
+
+(defn tap-c
+  [mult]
+  (let [c (async/chan)]
+    (async/tap mult c)
+    c))
+
+(defn close-and-reset! [chan-atom v]
+  (swap! chan-atom (fn [c]
+                     (when c
+                       (async/close! c))
+                     v)))
+
+(defn index-of
+  [coll pred]
+  (first (->> coll
+              (keep-indexed (fn [i v]
+                              (when (pred v)
+                                i))))))


### PR DESCRIPTION
Design decision: Use Jetty's websockets. Don't hide them under
core.async, just use them directly. Don't use a library that attempts
to solve websockets for Clojure and ClojureScript, just use the raw
API in the browser. I think there'd be lots of wrestling with
libraries, e.g. in configuring Transit write-handlers and
read-handlers, and it just seems best to work closer to the core APIs
until we find a good reason not to.

Created a way of sending channels over the network via "channel
proxies". Note that this is not the same as treating the websocket
itself as a channel.

Got rid of "sim-options". It was too hard to synchronize an atom
between two machines without causing ping-ponging. Do everything via
into-sim and subscribing to play/pause status.