### PR TITLE
Organize into "Server", "Bridge", and (default) Client

### DIFF
--- a/examples/cortical_io/comportexviz/cortical_io_demo.cljs
+++ b/examples/cortical_io/comportexviz/cortical_io_demo.cljs
@@ -9,7 +9,7 @@
             [clojure.string :as str]
             [comportexviz.main :as main]
             [comportexviz.helpers :as helpers]
-            [comportexviz.server.browser :as server]
+            [comportexviz.bridge.browser :as server]
             [comportexviz.util :as utilv]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]

--- a/examples/demos/comportexviz/demos/coordinates_2d.cljs
+++ b/examples/demos/comportexviz/demos/coordinates_2d.cljs
@@ -5,7 +5,7 @@
             [comportexviz.main :as main]
             [comportexviz.helpers :as helpers :refer [resizing-canvas]]
             [comportexviz.plots-canvas :as plt]
-            [comportexviz.server.browser :as server]
+            [comportexviz.bridge.browser :as server]
             [comportexviz.util :as utilv]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]

--- a/examples/demos/comportexviz/demos/fixed_seqs.cljs
+++ b/examples/demos/comportexviz/demos/fixed_seqs.cljs
@@ -8,7 +8,7 @@
             [comportexviz.main :as main]
             [comportexviz.helpers :as helpers :refer [resizing-canvas]]
             [comportexviz.plots-canvas :as plt]
-            [comportexviz.server.browser :as server]
+            [comportexviz.bridge.browser :as server]
             [comportexviz.util :as utilv]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]

--- a/examples/demos/comportexviz/demos/letters.cljs
+++ b/examples/demos/comportexviz/demos/letters.cljs
@@ -4,7 +4,7 @@
             [org.nfrac.comportex.util :as util]
             [comportexviz.main :as main]
             [comportexviz.helpers :as helpers]
-            [comportexviz.server.browser :as server]
+            [comportexviz.bridge.browser :as server]
             [comportexviz.util :as utilv]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]

--- a/examples/demos/comportexviz/demos/q_learning_1d.cljs
+++ b/examples/demos/comportexviz/demos/q_learning_1d.cljs
@@ -5,7 +5,7 @@
             [comportexviz.main :as main]
             [comportexviz.helpers :as helpers :refer [resizing-canvas]]
             [comportexviz.plots-canvas :as plt]
-            [comportexviz.server.browser :as server]
+            [comportexviz.bridge.browser :as server]
             [comportexviz.util :as utilv]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]

--- a/examples/demos/comportexviz/demos/q_learning_2d.cljs
+++ b/examples/demos/comportexviz/demos/q_learning_2d.cljs
@@ -6,7 +6,7 @@
             [comportexviz.main :as main]
             [comportexviz.helpers :as helpers :refer [resizing-canvas]]
             [comportexviz.plots-canvas :as plt]
-            [comportexviz.server.browser :as server]
+            [comportexviz.bridge.browser :as server]
             [comportexviz.util :as utilv]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]

--- a/examples/demos/comportexviz/demos/runner.cljs
+++ b/examples/demos/comportexviz/demos/runner.cljs
@@ -1,6 +1,6 @@
 (ns comportexviz.demos.runner
   (:require [comportexviz.main :as main]
-            [comportexviz.server.remote :as server]
+            [comportexviz.bridge.remote :as bridge]
             [reagent.core :as reagent :refer [atom]]
             [goog.dom :as dom]
             [cljs.core.async :as async])
@@ -17,7 +17,7 @@
   (reset! main/into-journal (async/chan))
 
   (let [into-sim (atom (async/chan))]
-    (server/init (str "ws://" js/location.host "/ws/")
+    (bridge/init (str "ws://" js/location.host "/ws/")
                  @main/into-journal
                  @into-sim
                  main/channel-proxies)

--- a/examples/demos/comportexviz/demos/second_level_motor.cljs
+++ b/examples/demos/comportexviz/demos/second_level_motor.cljs
@@ -5,7 +5,7 @@
             [comportexviz.helpers :as helpers :refer [resizing-canvas]]
             [comportexviz.plots-canvas :as plt]
             [comportexviz.demos.sensorimotor-1d :refer [draw-eye]]
-            [comportexviz.server.browser :as server]
+            [comportexviz.bridge.browser :as server]
             [comportexviz.util :as utilv]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]

--- a/examples/demos/comportexviz/demos/sensorimotor_1d.cljs
+++ b/examples/demos/comportexviz/demos/sensorimotor_1d.cljs
@@ -4,7 +4,7 @@
             [comportexviz.main :as main]
             [comportexviz.helpers :as helpers :refer [resizing-canvas]]
             [comportexviz.plots-canvas :as plt]
-            [comportexviz.server.browser :as server]
+            [comportexviz.bridge.browser :as server]
             [comportexviz.util :as utilv]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]

--- a/examples/demos/comportexviz/demos/simple_sentences.cljs
+++ b/examples/demos/comportexviz/demos/simple_sentences.cljs
@@ -4,7 +4,7 @@
             [org.nfrac.comportex.util :as util]
             [comportexviz.main :as main]
             [comportexviz.helpers :as helpers]
-            [comportexviz.server.browser :as server]
+            [comportexviz.bridge.browser :as server]
             [comportexviz.util :as utilv]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]

--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
             [com.cemerick/austin "0.1.6"]
             [org.clojure/tools.nrepl "0.2.10"]]
   :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]
-                 :init-ns comportexviz.launchpad}
+                 :init-ns comportexviz.server.launchpad}
 
   :source-paths ["src"]
 

--- a/public/demos/runner.html
+++ b/public/demos/runner.html
@@ -8,7 +8,7 @@
   <title>ComportexViz Runner</title>
 
   <!-- Bootstrap -->
-  <link rel="stylesheet" href="bootstrap-3.3.5-dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
 
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/src/comportexviz/bridge/README.md
+++ b/src/comportexviz/bridge/README.md
@@ -1,0 +1,3 @@
+# ComportexViz Bridge
+
+The ComportexViz client must be initialized with a bridge to a server. This server might run in the browser, it might run remotely, or it could potentially even be a static set of files that the bridge knows how to read. The bridge is responsible for making sure someone listens to the `into-journal` (required) and `into-sim` (optional) channels.

--- a/src/comportexviz/bridge/browser.cljs
+++ b/src/comportexviz/bridge/browser.cljs
@@ -1,4 +1,4 @@
-(ns comportexviz.server.browser
+(ns comportexviz.bridge.browser
   (:require [cljs.core.async :as async]
             [comportexviz.server.simulation :as simulation]
             [comportexviz.server.journal :as journal]

--- a/src/comportexviz/bridge/channel_proxy.cljc
+++ b/src/comportexviz/bridge/channel_proxy.cljc
@@ -1,4 +1,4 @@
-(ns comportexviz.server.channel-proxy
+(ns comportexviz.bridge.channel-proxy
   (:require #?(:clj [clojure.core.async :as async]
                :cljs [cljs.core.async :as async])
             #?(:clj
@@ -91,7 +91,7 @@
 
 ;;; ## Transit helpers
 
-(def channel-proxy-tag "comportexviz.server.channel-proxy.ChannelProxy")
+(def channel-proxy-tag "ChannelProxy")
 
 (def write-handler
   {ChannelProxy (transit/write-handler (fn [_]

--- a/src/comportexviz/bridge/remote.cljs
+++ b/src/comportexviz/bridge/remote.cljs
@@ -1,8 +1,7 @@
-(ns comportexviz.server.remote
+(ns comportexviz.bridge.remote
   (:require [cljs.core.async :as async :refer [put! close!]]
-            [clojure.set]
             [cognitect.transit :as transit]
-            [comportexviz.server.channel-proxy :as channel-proxy]
+            [comportexviz.bridge.channel-proxy :as channel-proxy]
             [org.nfrac.comportex.topology :refer [map->OneDTopology
                                                   map->TwoDTopology]])
   (:require-macros [cljs.core.async.macros :refer [go go-loop]]))

--- a/src/comportexviz/controls_ui.cljs
+++ b/src/comportexviz/controls_ui.cljs
@@ -9,7 +9,7 @@
             [cljs.reader]
             [comportexviz.helpers :as helpers]
             [comportexviz.plots :as plots]
-            [comportexviz.server.channel-proxy :as channel-proxy]
+            [comportexviz.bridge.channel-proxy :as channel-proxy]
             [org.nfrac.comportex.protocols :as p])
   (:require-macros [cljs.core.async.macros :refer [go go-loop]]))
 

--- a/src/comportexviz/main.cljs
+++ b/src/comportexviz/main.cljs
@@ -1,8 +1,6 @@
 (ns comportexviz.main
-  (:require [org.nfrac.comportex.core :as core]
-            [org.nfrac.comportex.protocols :as p]
-            [comportexviz.controls-ui :as cui]
-            [comportexviz.server.channel-proxy :as channel-proxy]
+  (:require [comportexviz.controls-ui :as cui]
+            [comportexviz.bridge.channel-proxy :as channel-proxy]
             [comportexviz.viz-canvas :as viz]
             [reagent.core :as reagent :refer [atom]]
             [cljs.core.async :as async :refer [chan put! <!]])

--- a/src/comportexviz/plots.cljs
+++ b/src/comportexviz/plots.cljs
@@ -3,7 +3,7 @@
             [monet.canvas :as c]
             [comportexviz.plots-canvas :as plt]
             [comportexviz.helpers :refer [canvas]]
-            [comportexviz.server.channel-proxy :as channel-proxy]
+            [comportexviz.bridge.channel-proxy :as channel-proxy]
             [org.nfrac.comportex.core :as core]
             [org.nfrac.comportex.util :as util]
             [clojure.string :as str]

--- a/src/comportexviz/server/README.md
+++ b/src/comportexviz/server/README.md
@@ -1,0 +1,18 @@
+# ComportexViz Server
+
+The server runs a "simulation" and maintains a "journal".
+
+The server listens to two channels, one for the simulation and one for the journal. The client sends messages into these channels to control the simulation and to request / subscribe to content. The server responds by putting values on client-provided channels. To put a value v on a channel remotely, send
+
+~~~clojure
+[target-id :put! v]
+~~~
+
+into the websocket. This `target-id` is provided by the client. The client sends similar messages to the server, e.g.
+
+~~~clojure
+;; 24601 and 24602 are target-ids
+[:into-journal :put! [:subscribe 40 24601 24602]]
+~~~
+
+This server doesn't serve HTM models directly to the client. It serves a description of "what to draw". It serves content. In other words, it's a webserver, not a database. The format of these "what to draw" descriptions is different for each command.

--- a/src/comportexviz/server/details.cljc
+++ b/src/comportexviz/server/details.cljc
@@ -1,4 +1,4 @@
-(ns comportexviz.details
+(ns comportexviz.server.details
   (:require [clojure.string :as str]
             [org.nfrac.comportex.core :as core]
             [org.nfrac.comportex.protocols :as p]))

--- a/src/comportexviz/server/journal.cljc
+++ b/src/comportexviz/server/journal.cljc
@@ -1,7 +1,7 @@
 (ns comportexviz.server.journal
   (:require #?(:clj [clojure.core.async :as async :refer [put! <! go go-loop]]
                :cljs [cljs.core.async :as async :refer [put! <!]])
-            [comportexviz.details]
+            [comportexviz.server.details]
             [comportexviz.server.data :as data]
             [org.nfrac.comportex.core :as core]
             [org.nfrac.comportex.protocols :as p]
@@ -107,7 +107,7 @@
                   id (:model-id sel)]
               (put! response-c
                     (if-let [[prev-htm htm] (find-model-pair id)]
-                      (comportexviz.details/detail-text htm prev-htm sel)
+                      (comportexviz.server.details/detail-text htm prev-htm sel)
                       (id-missing-response id steps-offset))))
 
             :get-model

--- a/src/comportexviz/server/launchpad.clj
+++ b/src/comportexviz/server/launchpad.clj
@@ -1,4 +1,4 @@
-(ns comportexviz.launchpad
+(ns comportexviz.server.launchpad
   (:require [clojure.core.async :as async]
             [comportexviz.server.runner :as runner]))
 

--- a/src/comportexviz/server/runner.clj
+++ b/src/comportexviz/server/runner.clj
@@ -5,7 +5,7 @@
             [compojure.core :refer [defroutes GET]]
             [compojure.route :as route]
             [org.nfrac.comportex.core]
-            [comportexviz.server.channel-proxy :as channel-proxy]
+            [comportexviz.bridge.channel-proxy :as channel-proxy]
             [comportexviz.server.simulation :as simulation]
             [comportexviz.server.journal :as journal]
             [comportexviz.util :as utilv])

--- a/src/comportexviz/server/simulation.cljc
+++ b/src/comportexviz/server/simulation.cljc
@@ -1,7 +1,6 @@
 (ns comportexviz.server.simulation
   (:require #?(:clj [clojure.core.async :as async :refer [put! <! go go-loop]]
                :cljs [cljs.core.async :as async :refer [put! <!]])
-            [comportexviz.details]
             [org.nfrac.comportex.core :as core]
             [org.nfrac.comportex.protocols :as p]
             [org.nfrac.comportex.util :as util])

--- a/src/comportexviz/viz_canvas.cljs
+++ b/src/comportexviz/viz_canvas.cljs
@@ -8,12 +8,11 @@
             [goog.dom :as dom]
             [comportexviz.dom :refer [offset-from-target]]
             [comportexviz.helpers :as helpers :refer [resizing-canvas]]
-            [comportexviz.server.channel-proxy :as channel-proxy]
+            [comportexviz.bridge.channel-proxy :as channel-proxy]
             [comportexviz.util :as utilv :refer [tap-c]]
             [monet.canvas :as c]
             [org.nfrac.comportex.protocols :as p]
             [org.nfrac.comportex.util :as util]
-            [clojure.set :as set]
             [cljs.core.async :as async :refer [<! put! chan]])
   (:require-macros [cljs.core.async.macros :refer [go go-loop]]
                    [comportexviz.macros :refer [with-cache]]))


### PR DESCRIPTION
Remove all references to comportexviz.server from the Client code. It
talks to bridges. Bridges might talk to comportexviz.server code
(in-browser simulations), or might talk to remote servers.

Fix a bug where runner.html only worked in my dev environment. Oops.