### PR TITLE
Make the viz-canvas grow to fit its contents

### DIFF
--- a/examples/demos/comportexviz/demos/notebook.cljs
+++ b/examples/demos/comportexviz/demos/notebook.cljs
@@ -69,9 +69,7 @@
         (reagent/render [:div
                          (when (> (count @steps) 1)
                            [viz/viz-timeline steps selection viz-options])
-                         [viz/viz-canvas {:style {:width "100%"
-                                                  :height "100vh"}
-                                          :tabIndex 0} steps
+                         [viz/viz-canvas {:tabIndex 0} steps
                           selection step-template viz-options nil nil
                           (atom into-journal) local-targets]]
                         el)))))

--- a/src/comportexviz/server/data.cljc
+++ b/src/comportexviz/server/data.cljc
@@ -158,7 +158,7 @@
           (recur (first more) (next more) path->synapses)
           path->synapses)))))
 
-(defn cell-segments-data
+(defn cells-segments-data
   [htm prev-htm sel-rgn sel-lyr col sel-ci-si opts]
   (let [regions (:regions htm)
         lyr (get-in regions [sel-rgn sel-lyr])

--- a/src/comportexviz/server/journal.cljc
+++ b/src/comportexviz/server/journal.cljc
@@ -144,13 +144,13 @@
                       (data/ff-out-synapses-data htm inp-id bit opts)
                       (id-missing-response id steps-offset))))
 
-            :get-cell-segments
+            :get-cells-segments
             (let [[id rgn-id lyr-id col ci-si token response-c] xs
                   [opts] (get-in @client-info [journal-id ::viewports token])]
               (put! response-c
                     (if-let [[prev-htm htm] (find-model-pair id)]
-                      (data/cell-segments-data htm prev-htm rgn-id lyr-id col
-                                               ci-si opts)
+                      (data/cells-segments-data htm prev-htm rgn-id lyr-id col
+                                                ci-si opts)
                       (id-missing-response id steps-offset))))
 
             :get-details-text

--- a/src/comportexviz/viz_canvas.cljs
+++ b/src/comportexviz/viz_canvas.cljs
@@ -1161,8 +1161,6 @@
 
         (add-watch cells-segs-response ::cells-segments-layout
                    (fn [_ _ _ [sel1 cells-segments]]
-                     ;; TODO solve the inconsistency of "cells-segments" or
-                     ;; multiple people will punch themselves
                      (swap! viz-layouts assoc :cells-segments
                             (when cells-segments
                               (let [n-segs-by-cell (->> cells-segments


### PR DESCRIPTION
Rather than sizing the viz-canvas via CSS, let it size itself, and
impose limits via a max-height and max-width in the viz-options.

This is important for the notebook, where whitespace is gross.

This means we now resize this canvas via script, not CSS. With CSS it
would be difficult for the component to know whether it should
maintain its current size. Now there's a single pair of authoritative
numbers.

This required calculating the cells-segments layout before render,
similar to the other layouts. So the cells-segments layout now lives
inside viz-layouts.

I removed awareness of the source layout, bit, and dt from the
cells-segments layout. The method that uses those now takes them as
params. This matches other nearby usage, e.g. drawing distal synapses
from segments to other regions, whereas it's awkward to grab this
information at my new layout calculation point.

Also:

- Fix a bug I recently put in the viz-timeline. Now it listens to
  window resize.
- Change some occurrences of "cell-segs" to "cells-segs" in hopes of
  preventing future pain.
- Don't draw breaks in 2D.