### PR TITLE
Separate encoders from senses

### DIFF
--- a/examples/cortical_io/comportexviz/cortical_io_demo.cljs
+++ b/examples/cortical_io/comportexviz/cortical_io_demo.cljs
@@ -157,7 +157,7 @@ fox eat something.
         predictions-cache (atom {})
         selected-htm (atom nil)]
     (add-watch main/selection ::fetch-selected-htm
-               (fn [_ _ _ sel]
+               (fn [_ _ _ [sel]]
                  (when-let [model-id (:model-id sel)]
                    (let [out-c (async/chan)]
                      (put! @main/into-journal [:get-model model-id out-c])

--- a/examples/cortical_io/comportexviz/cortical_io_demo.cljs
+++ b/examples/cortical_io/comportexviz/cortical_io_demo.cljs
@@ -135,10 +135,10 @@ fox eat something.
 
 (defn load-predictions
   [in-value htm n-predictions predictions-cache]
-  (let [inp (first (core/input-seq htm))
+  (let [e (first (vals (:encoders htm)))
         rgn (first (core/region-seq htm))
         pr-votes (core/predicted-bit-votes rgn)
-        predictions (p/decode (:encoder inp) pr-votes n-predictions)]
+        predictions (p/decode e pr-votes n-predictions)]
     (if-let [c (:channel predictions)]
       ;; async call, return nil and await cache (like a promise)
       (do
@@ -164,24 +164,26 @@ fox eat something.
                      (go
                        (reset! selected-htm (<! out-c)))))))
     (fn []
-      (when-let [htm @selected-htm]
-        (let [in-value (:value (first (core/input-seq htm)))]
-          [:div
-           [:p.muted [:small "Input on selected timestep."]]
-           [:div {:style {:min-height "40vh"}}
-            (helpers/text-world-input-component in-value htm max-shown scroll-every " ")]
-           [:div
-            [:button.btn.btn-default.btn-block {:class (if @show-predictions "active")
-                                                :on-click (fn [e]
-                                                            (swap! show-predictions not)
-                                                            (.preventDefault e))}
-             "Compute predictions"]]
-           (when @show-predictions
-             (if-let [predictions (or (get @predictions-cache htm)
-                                      (load-predictions in-value htm 8 predictions-cache))]
-               (helpers/predictions-table predictions)
-               ;; not cached and not returned immediately
-               [:p.text-info "Loading predictions..."]))])))))
+      (when-let [step (main/selected-step)]
+        (when-let [htm @selected-htm]
+          (let [in-value (:input-value step)]
+            [:div
+             [:p.muted [:small "Input on selected timestep."]]
+             [:div {:style {:min-height "40vh"}}
+              (helpers/text-world-input-component in-value htm max-shown
+                                                  scroll-every " ")]
+             [:div
+              [:button.btn.btn-default.btn-block {:class (if @show-predictions "active")
+                                                  :on-click (fn [e]
+                                                              (swap! show-predictions not)
+                                                              (.preventDefault e))}
+               "Compute predictions"]]
+             (when @show-predictions
+               (if-let [predictions (or (get @predictions-cache htm)
+                                        (load-predictions in-value htm 8 predictions-cache))]
+                 (helpers/predictions-table predictions)
+                 ;; not cached and not returned immediately
+                 [:p.text-info "Loading predictions..."]))]))))))
 
 (defn split-sentences
   [text]
@@ -232,7 +234,7 @@ fox eat something.
         spec (case (:spec-choice @config)
                :a spec-global
                :b spec-local)
-        inp (->>
+        enc (->>
              (case (:encoder @config)
                :cortical-io
                (cortical-io-encoder (:api-key @config) fingerprint-cache
@@ -241,11 +243,10 @@ fox eat something.
                :random
                (enc/unique-encoder cio/retina-dim
                                    (apply * 0.02 cio/retina-dim)))
-             (enc/pre-transform :word)
-             (core/sensory-input))]
+             (enc/pre-transform :word))]
     (with-ui-loading-message
       (reset! model (core/regions-in-series
-                     core/sensory-region inp n-regions
+                     core/sensory-region enc n-regions
                      (list* spec (repeat (merge spec higher-level-spec-diff)))))
       (server/init model
                    world-c

--- a/examples/demos/comportexviz/demos/coordinates_2d.cljs
+++ b/examples/demos/comportexviz/demos/coordinates_2d.cljs
@@ -108,7 +108,7 @@
 (defn world-pane
   []
   (when-let [step (main/selected-step)]
-    (let [in-value (first (:input-values step))
+    (let [in-value (:input-value step)
           {:keys [x y vx vy]} in-value]
       [:div
        [:p.muted [:small "Input on selected timestep."]]
@@ -122,7 +122,7 @@
         [main/selection]
         (fn [ctx]
           (let [step (main/selected-step)
-                in-value (first (:input-values step))]
+                in-value (:input-value step)]
             (draw-world ctx in-value)))
         nil]])))
 

--- a/examples/demos/comportexviz/demos/fixed_seqs.cljs
+++ b/examples/demos/comportexviz/demos/fixed_seqs.cljs
@@ -93,7 +93,7 @@
 (defn world-pane
   []
   (when-let [step (main/selected-step)]
-    (let [in-value (first (:input-values step))
+    (let [in-value (:input-value step)
           model-id (::model-id (meta in-value))
           {:keys [patterns mixed? xy?]} (model-info model-id)
           currs (pattern-index-map in-value mixed? model-id)]
@@ -117,7 +117,7 @@
         [main/selection]
         (fn [ctx]
           (let [step (main/selected-step)
-                in-value (first (:input-values step))
+                in-value (:input-value step)
                 model-id (::model-id (meta in-value))
                 {:keys [patterns mixed? xy?]} (model-info model-id)
                 currs (pattern-index-map in-value mixed? model-id)]

--- a/examples/demos/comportexviz/demos/letters.cljs
+++ b/examples/demos/comportexviz/demos/letters.cljs
@@ -67,7 +67,7 @@ Chifung has a friend."))
     (fn []
       (when-let [step (main/selected-step)]
         (when-let [htm @selected-htm]
-          (let [in-value (first (:input-values step))]
+          (let [in-value (:input-value step)]
             [:div
              [:p.muted [:small "Input on selected timestep."]]
              [:div {:style {:min-height "40vh"}}

--- a/examples/demos/comportexviz/demos/letters.cljs
+++ b/examples/demos/comportexviz/demos/letters.cljs
@@ -58,7 +58,7 @@ Chifung has a friend."))
   (let [show-predictions (atom false)
         selected-htm (atom nil)]
     (add-watch main/selection ::fetch-selected-htm
-               (fn [_ _ _ sel]
+               (fn [_ _ _ [sel]]
                  (when-let [model-id (:model-id sel)]
                    (let [out-c (async/chan)]
                      (put! @main/into-journal [:get-model model-id out-c])

--- a/examples/demos/comportexviz/demos/q_learning_1d.cljs
+++ b/examples/demos/comportexviz/demos/q_learning_1d.cljs
@@ -160,7 +160,7 @@
   []
   (let [selected-htm (atom nil)]
     (add-watch main/selection ::fetch-selected-htm
-               (fn [_ _ _ sel]
+               (fn [_ _ _ [sel]]
                  (when-let [model-id (:model-id sel)]
                    (let [out-c (async/chan)]
                      (put! @main/into-journal [:get-model model-id out-c])

--- a/examples/demos/comportexviz/demos/q_learning_1d.cljs
+++ b/examples/demos/comportexviz/demos/q_learning_1d.cljs
@@ -169,7 +169,7 @@
     (fn []
       (when-let [step (main/selected-step)]
         (when-let [htm @selected-htm]
-          (let [in-value (first (:input-values step))
+          (let [in-value (:input-value step)
                 DELTA (gstr/unescapeEntities "&Delta;")
                 TIMES (gstr/unescapeEntities "&times;")]
             [:div
@@ -201,7 +201,7 @@
               [main/selection]
               (fn [ctx]
                 (let [step (main/selected-step)
-                      in-value (first (:input-values step))]
+                      in-value (:input-value step)]
                   (draw-world ctx in-value)))
               nil]
              [:small

--- a/examples/demos/comportexviz/demos/q_learning_2d.cljs
+++ b/examples/demos/comportexviz/demos/q_learning_2d.cljs
@@ -96,7 +96,7 @@
   []
   (let [selected-htm (atom nil)]
     (add-watch main/selection ::fetch-selected-htm
-               (fn [_ _ _ sel]
+               (fn [_ _ _ [sel]]
                  (when-let [model-id (:model-id sel)]
                    (let [out-c (async/chan)]
                      (put! @main/into-journal [:get-model model-id out-c])

--- a/examples/demos/comportexviz/demos/q_learning_2d.cljs
+++ b/examples/demos/comportexviz/demos/q_learning_2d.cljs
@@ -105,7 +105,7 @@
     (fn []
       (when-let [step (main/selected-step)]
         (when-let [htm @selected-htm]
-          (let [in-value (first (:input-values step))
+          (let [in-value (:input-value step)
                 DELTA (gstr/unescapeEntities "&Delta;")
                 TIMES (gstr/unescapeEntities "&times;")]
             [:div
@@ -135,7 +135,7 @@
               [main/selection selected-htm]
               (fn [ctx]
                 (let [step (main/selected-step)
-                      in-value (first (:input-values step))]
+                      in-value (:input-value step)]
                   (draw-world ctx in-value @selected-htm)))
               nil]
              [:small

--- a/examples/demos/comportexviz/demos/second_level_motor.cljs
+++ b/examples/demos/comportexviz/demos/second_level_motor.cljs
@@ -106,7 +106,7 @@
 (defn world-pane
   []
   (when-let [step (main/selected-step)]
-    (let [in-value (first (:input-values step))
+    (let [in-value (:input-value step)
           {:keys [sentences position]} in-value
           [i j k] position
           letter-sacc (:next-letter-saccade in-value)
@@ -134,7 +134,7 @@
         [main/selection]
         (fn [ctx]
           (let [step (main/selected-step)
-                in-value (first (:input-values step))]
+                in-value (:input-value step)]
             (draw-world ctx in-value)))
         nil]
        [:pre
@@ -199,7 +199,7 @@
    [:p "The world is a string of letters divided into words and
    sentences. Only one letter is received as direct sensory input at
    any one time. Motor actions (saccades) shift the focus to a new
-   letter. These motor actions are encoded in two separate inputs: "
+   letter. These motor actions are encoded in two separate senses: "
     [:code "letter-motor"] " and " [:code "word-motor"]
     ". The former is distal input to the first level region, while the
     latter is distal input to the second-level region."]

--- a/examples/demos/comportexviz/demos/sensorimotor_1d.cljs
+++ b/examples/demos/comportexviz/demos/sensorimotor_1d.cljs
@@ -126,7 +126,7 @@
 (defn world-pane
   []
   (when-let [step (main/selected-step)]
-    (let [in-value (first (:input-values step))
+    (let [in-value (:input-value step)
           {:keys [field position next-saccade]} in-value]
       [:div
        [:p.muted [:small "Input on selected timestep."]]
@@ -140,7 +140,7 @@
         [main/selection]
         (fn [ctx]
           (let [step (main/selected-step)
-                in-value (first (:input-values step))]
+                in-value (:input-value step)]
             (draw-world ctx in-value)))
         nil]])))
 

--- a/examples/demos/comportexviz/demos/simple_sentences.cljs
+++ b/examples/demos/comportexviz/demos/simple_sentences.cljs
@@ -45,7 +45,7 @@
         selected-htm (atom nil)]
 
     (add-watch main/selection ::fetch-selected-htm
-               (fn [_ _ _ sel]
+               (fn [_ _ _ [sel]]
                  (when-let [model-id (:model-id sel)]
                    (let [out-c (async/chan)]
                      (put! @main/into-journal [:get-model model-id out-c])

--- a/examples/demos/comportexviz/demos/simple_sentences.cljs
+++ b/examples/demos/comportexviz/demos/simple_sentences.cljs
@@ -55,7 +55,7 @@
     (fn []
       (when-let [step (main/selected-step)]
         (when-let [htm @selected-htm]
-         (let [in-value (first (:input-values step))]
+          (let [in-value (:input-value step)]
            [:div
             [:p.muted [:small "Input on selected timestep."]]
             [:div {:style {:min-height "40vh"}}

--- a/examples/worksheets/hello.clj
+++ b/examples/worksheets/hello.clj
@@ -2,7 +2,7 @@
 
 ;; **
 ;;; # Comportex
-;;; 
+;;;
 ;; **
 
 ;; **
@@ -45,7 +45,7 @@
 
 (def model (core/regions-in-series
             core/sensory-region
-            (core/sensory-input encoder) 1
+            encoder 1
             (repeat spec)))
 
 (def inputs (flatten (repeat (range 0 12))))
@@ -94,9 +94,7 @@
 ;; @@
 (defn t->input [t]
   (-> (nth timeline t)
-      core/input-seq
-      first
-      :value))
+      :input-value))
 
 (defn t->prediction [t]
   (when (> t 0)

--- a/project.clj
+++ b/project.clj
@@ -1,26 +1,26 @@
-(defproject comportexviz "0.0.9-SNAPSHOT"
+(defproject comportexviz "0.0.10-SNAPSHOT"
   :description "Web visualisation of HTM algorithm as implemented in comportex"
   :url "https://github.com/nupic-community/comportexviz"
 
-  :dependencies [[org.clojure/clojure "1.7.0-RC1"]
-                 [org.clojure/clojurescript "0.0-3308"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [org.clojure/clojurescript "1.7.107"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
                  [tailrecursion/cljs-priority-map "1.1.0"]
-                 [org.nfrac/comportex "0.0.9-SNAPSHOT"]
+                 [org.nfrac/comportex "0.0.10-SNAPSHOT"]
                  [rm-hull/monet "0.2.1"]
                  [reagent "0.5.0"]
-                 [reagent-forms "0.5.1"]
+                 [reagent-forms "0.5.6"]
                  [ring/ring-core "1.4.0"]
                  [compojure "1.4.0"]
                  [info.sunng/ring-jetty9-adapter "0.9.1"]
-                 [com.cognitect/transit-clj "0.8.275"]
+                 [com.cognitect/transit-clj "0.8.281"]
                  [com.cognitect/transit-cljs "0.8.220"]
                  [com.mrcslws/gorilla-repl "0.3.5-004"
                   :exclusions [javax.servlet/servlet-api
                                org.slf4j/slf4j-api]]
-                 [org.clojure/data.csv "0.1.2"]]
+                 [org.clojure/data.csv "0.1.3"]]
 
-  :plugins [[lein-cljsbuild "1.0.6"]
+  :plugins [[lein-cljsbuild "1.1.0"]
             [com.cemerick/austin "0.1.6"]
             [org.clojure/tools.nrepl "0.2.10"]]
   :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]

--- a/src/comportexviz/controls_ui.cljs
+++ b/src/comportexviz/controls_ui.cljs
@@ -306,10 +306,10 @@
          " Draw one step in 2D"]]
        ]]
      [:div.row
-      (group "Inputs"
+      (group "Inbits"
              [:div.panel-body
-              (chbox :input.active "Active bits")
-              (chbox :input.predicted "Predicted bits")
+              (chbox :inbits.active "Active bits")
+              (chbox :inbits.predicted "Predicted bits")
               ])
       (group "Columns"
              [:div.panel-body
@@ -652,7 +652,7 @@
             "ComportexViz"]
         " runs HTM models in the browser with interactive
        controls. The model state from recent timesteps is kept, so you can step
-       back in time. You can inspect input values, encoded input bits, and the
+       back in time. You can inspect input values, encoded sense bits, and the
        columns that make up cortical region layers. Within a column you can inspect
        cells and their distal dendrite segments. Feed-forward and distal synapses
        can be shown."]]
@@ -660,7 +660,7 @@
        [:h4 "Display"]
        [:p "Kept timesteps are shown in a row at the top of the display.
       Click one to jump to it.
-      Below that, the blocks represent input fields (squares) and
+      Below that, the blocks represent sensory fields (squares) and
       layers of cortical columns (circles). Depending on the display mode,
       these may be shown in 2D grids from a single time step, or as one
       vertical line per timestep, allowing several time steps to be shown

--- a/src/comportexviz/helpers.cljs
+++ b/src/comportexviz/helpers.cljs
@@ -76,10 +76,10 @@
 
 (defn text-world-predictions-component
   [in-value htm n-predictions]
-  (let [inp (first (core/input-seq htm))
+  (let [e (first (vals (:encoders htm)))
         rgn (first (core/region-seq htm))
         pr-votes (core/predicted-bit-votes rgn)
-        predictions (p/decode (:encoder inp) pr-votes n-predictions)]
+        predictions (p/decode e pr-votes n-predictions)]
     (predictions-table predictions)))
 
 ;;; canvas

--- a/src/comportexviz/plots.cljs
+++ b/src/comportexviz/plots.cljs
@@ -213,7 +213,7 @@
 
 (defn viz-rgn-shades
   [step-template]
-  (let [srcs (concat (keys (:inputs @step-template))
+  (let [srcs (concat (keys (:senses @step-template))
                      (keys (:regions @step-template)))]
     (zipmap srcs (range -0.3 0.31 (/ 1.0 (count srcs))))))
 
@@ -452,7 +452,7 @@
                                 (fn [m]
                                   (util/update-each (or m {}) lc
                                                     #(merge-with + % {which-sdr 1}))))
-                         (let [label (:label (first (:input-values (first step))))]
+                         (let [label (:label (:input-value (first step)))]
                            (swap! sdr-label-counts
                                   update [region-key layer-id]
                                   (fn [m]

--- a/src/comportexviz/selection.cljs
+++ b/src/comportexviz/selection.cljs
@@ -2,10 +2,10 @@
 
 (def blank-selection [])
 
-(defn input
+(defn sense
   [sel1]
   (let [[t a1] (:path sel1)]
-    (when (= t :inputs)
+    (when (= t :senses)
       a1)))
 
 (defn layer

--- a/src/comportexviz/server/details.cljc
+++ b/src/comportexviz/server/details.cljc
@@ -13,9 +13,9 @@
   (let [rgn (get-in htm [:regions rgn-id])
         lyr (get rgn lyr-id)
         depth (p/layer-depth lyr)
-        inp (first (core/input-seq htm))
-        in (:value inp)
-        bits (p/bits-value inp)]
+        in (:input-value htm)
+        sense-node (first (vals (:senses htm)))
+        bits (p/bits-value sense-node)]
     (->>
      ["__Selection__"
       (str "* timestep " (p/timestep rgn))

--- a/src/comportexviz/server/journal.cljc
+++ b/src/comportexviz/server/journal.cljc
@@ -16,7 +16,7 @@
   [model id]
   {:model-id id
    :timestep (p/timestep model)
-   :input-values (->> model core/input-seq (map :value))})
+   :input-value (:input-value model)})
 
 (defn id-missing-response
   [id steps-offset]
@@ -144,11 +144,11 @@
                       (id-missing-response id steps-offset))))
 
             :get-ff-out-synapses
-            (let [[id inp-id bit token response-c] xs
+            (let [[id sense-id bit token response-c] xs
                   [opts] (get-in @client-info [journal-id ::viewports token])]
               (put! response-c
                     (if-let [htm (find-model id)]
-                      (data/ff-out-synapses-data htm inp-id bit opts)
+                      (data/ff-out-synapses-data htm sense-id bit opts)
                       (id-missing-response id steps-offset))))
 
             :get-cells-segments


### PR DESCRIPTION
Updates to work with nupic-community/comportex#26

Rename inputs to senses, etc.