### PR TITLE
Channels not in atoms

### DIFF
--- a/examples/cortical_io/comportexviz/cortical_io_demo.cljs
+++ b/examples/cortical_io/comportexviz/cortical_io_demo.cljs
@@ -356,7 +356,7 @@ fox eat something.
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane (atom into-sim)]
+  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
                   (dom/getElement "comportexviz-app"))
   (swap! main/viz-options assoc-in [:drawing :display-mode] :two-d)
   (put! into-sim [:run]))

--- a/examples/demos/comportexviz/demos/coordinates_2d.cljs
+++ b/examples/demos/comportexviz/demos/coordinates_2d.cljs
@@ -6,6 +6,7 @@
             [comportexviz.helpers :as helpers :refer [resizing-canvas]]
             [comportexviz.plots-canvas :as plt]
             [comportexviz.bridge.browser :as server]
+            [comportexviz.server.data :as data]
             [comportexviz.util :as utilv]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]
@@ -30,8 +31,9 @@
                           :history))
                     (map #(assoc % :label (quadrant %))))))
 
-(def into-sim
-  (atom nil))
+(def model (atom nil))
+
+(def into-sim (async/chan))
 
 (def control-c (async/chan))
 
@@ -134,13 +136,14 @@
 
 (defn set-model!
   []
-  (utilv/close-and-reset! into-sim (async/chan))
-  (utilv/close-and-reset! main/into-journal (async/chan))
   (with-ui-loading-message
-    (server/init (demo/n-region-model (:n-regions @config))
-                 world-c
-                 @main/into-journal
-                 @into-sim)))
+    (let [init? (nil? @model)]
+      (reset! model (demo/n-region-model (:n-regions @config)))
+      (if init?
+        (server/init model world-c main/into-journal into-sim)
+        (reset! main/step-template (data/step-template-data @model)))
+      (when init?
+        (feed-world!)))))
 
 (def config-template
   [:div.form-horizontal
@@ -194,8 +197,7 @@
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
+  (reagent/render [main/comportexviz-app model-tab world-pane (atom into-sim)]
                   (dom/getElement "comportexviz-app"))
   (swap! main/viz-options assoc-in [:drawing :display-mode] :two-d)
-  (feed-world!)
   (set-model!))

--- a/examples/demos/comportexviz/demos/coordinates_2d.cljs
+++ b/examples/demos/comportexviz/demos/coordinates_2d.cljs
@@ -197,7 +197,7 @@
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane (atom into-sim)]
+  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
                   (dom/getElement "comportexviz-app"))
   (swap! main/viz-options assoc-in [:drawing :display-mode] :two-d)
   (set-model!))

--- a/examples/demos/comportexviz/demos/fixed_seqs.cljs
+++ b/examples/demos/comportexviz/demos/fixed_seqs.cljs
@@ -130,6 +130,6 @@
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane (atom into-sim)]
+  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
                   (dom/getElement "comportexviz-app"))
   (set-model!))

--- a/examples/demos/comportexviz/demos/fixed_seqs.cljs
+++ b/examples/demos/comportexviz/demos/fixed_seqs.cljs
@@ -1,61 +1,34 @@
 (ns comportexviz.demos.fixed-seqs
-  (:require [org.nfrac.comportex.demos.directional-steps-1d :as demo-dir]
-            [org.nfrac.comportex.demos.isolated-1d :as demo-i1d]
-            [org.nfrac.comportex.demos.mixed-gaps-1d :as demo-mix]
-            [org.nfrac.comportex.demos.isolated-2d :as demo-i2d]
+  (:require [org.nfrac.comportex.demos.isolated-1d :as demo]
             [org.nfrac.comportex.core :as core]
             [org.nfrac.comportex.util :as util]
             [comportexviz.main :as main]
             [comportexviz.helpers :as helpers :refer [resizing-canvas]]
             [comportexviz.plots-canvas :as plt]
             [comportexviz.bridge.browser :as server]
+            [comportexviz.server.data :as data]
             [comportexviz.util :as utilv]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]
             [goog.dom :as dom]
             [cljs.core.async :as async :refer [put!]])
-  (:require-macros [comportexviz.macros :refer [with-ui-loading-message]]))
+  (:require-macros [cljs.core.async.macros :refer [go]]
+                   [comportexviz.macros :refer [with-ui-loading-message]]))
 
 (def config
-  (atom {:input-stream :directional-steps-1d
-         :n-regions 1}))
+  (atom {:n-regions 1}))
 
-(def world-c
-  (atom nil))
+(def world-c (async/chan (async/buffer 1)
+                         (map #(assoc % :label (:id %)))))
 
-(def into-sim
-  (atom nil))
+(def model (atom nil))
 
-(def model-info
-  {:directional-steps-1d {:model-fn demo-dir/n-region-model
-                          :world-fn demo-dir/input-seq
-                          :patterns {:dir [[0 1] [0 -1]]
-                                     :pos (plt/indexed (range (inc demo-dir/numb-max)))}
-                          :mixed? true
-                          :xy? true}
-   :isolated-1d {:model-fn demo-i1d/n-region-model
-                 :world-fn demo-i1d/input-seq
-                 :patterns demo-i1d/patterns
-                 :mixed? false
-                 :xy? false}
-   :mixed-gaps-1d {:model-fn demo-mix/n-region-model
-                   :world-fn demo-mix/input-seq
-                   :patterns demo-mix/patterns
-                   :mixed? true
-                   :xy? false}
-   :isolated-2d {:model-fn demo-i2d/n-region-model
-                 :world-fn demo-i2d/input-seq
-                 :patterns demo-i2d/patterns
-                 :mixed? false
-                 :xy? true}})
+(def into-sim (async/chan))
 
 (defn draw-world
-  "Currs should be a map from patt-id to index (current position in the pattern)."
-  [ctx currs patterns xy?]
-  (let [patterns-xy (if xy?
-                      patterns
-                      (util/remap plt/indexed patterns))
+  [ctx inval patterns]
+  (let [patterns-xy (util/remap plt/indexed patterns)
         x-max (reduce max (map first (mapcat val patterns-xy)))
         y-max (reduce max (map second (mapcat val patterns-xy)))
         x-lim [(- 0 1) (+ x-max 1)]
@@ -70,33 +43,16 @@
     (c/stroke-style ctx "lightgray")
     (plt/grid! plot {})
     (c/stroke-style ctx "black")
-    (doseq [[patt-id index] currs]
-      (plt/line! plot (patterns-xy patt-id))
-      (doseq [[i [x y]] (plt/indexed (patterns-xy patt-id))]
-        (c/fill-style ctx (if (== i index) "red" "lightgrey"))
+    (when-let [id (:id inval)]
+      (plt/line! plot (patterns-xy id))
+      (doseq [[i [x y]] (plt/indexed (patterns-xy id))]
+        (c/fill-style ctx (if (== i (:index inval)) "red" "lightgrey"))
         (plt/point! plot x y 4)))))
-
-(defn pattern-index-map
-  [in-value mixed? model-id]
-  (case model-id
-    :directional-steps-1d
-    (let [[dir i] in-value]
-      {:dir (case dir :up 0 :down 1)
-       :pos i})
-    ;; default case
-    (if mixed?
-      in-value
-      (when (:id in-value)
-        {(:id in-value) (:index in-value)}))
-    ))
 
 (defn world-pane
   []
   (when-let [step (main/selected-step)]
-    (let [in-value (:input-value step)
-          model-id (::model-id (meta in-value))
-          {:keys [patterns mixed? xy?]} (model-info model-id)
-          currs (pattern-index-map in-value mixed? model-id)]
+    (let [inval (:input-value step)]
       [:div
        [:p.muted [:small "Input on selected timestep."]]
        [:table.table
@@ -104,61 +60,31 @@
          [:tr
           [:th "pattern"]
           [:th "value"]]
-         (for [[patt-id v] currs]
-           ^{:key (str patt-id v)}
-           [:tr
-            [:td (str patt-id)]
-            [:td v
-             (when (and (= model-id :directional-steps-1d)
-                        (= patt-id :dir))
-               (str " (" (first in-value) ")"))]])]]
+         [:tr
+          [:td (str (or (:id inval) "-"))]
+          [:td (:value inval)]]]]
        [resizing-canvas {:style {:width "100%"
                                  :height "300px"}}
         [main/selection]
         (fn [ctx]
           (let [step (main/selected-step)
-                in-value (:input-value step)
-                model-id (::model-id (meta in-value))
-                {:keys [patterns mixed? xy?]} (model-info model-id)
-                currs (pattern-index-map in-value mixed? model-id)]
-            (draw-world ctx currs patterns xy?)))
+                inval (:input-value step)]
+            (draw-world ctx inval demo/patterns)))
         nil]])))
-
-(defn make-world-chan
-  [world-seq-fn model-id]
-  (let [world-c (async/chan (async/buffer 1)
-                            (map #(vary-meta % assoc ::model-id model-id)))]
-    (async/onto-chan world-c (world-seq-fn) false)
-    world-c))
 
 (defn set-model!
   []
-  (utilv/close-and-reset! main/into-journal (async/chan))
-  (utilv/close-and-reset! into-sim (async/chan))
-  (put! @into-sim [:run])
-
-  (let [{:keys [input-stream n-regions]} @config
-        {:keys [model-fn world-fn xy?]} (model-info input-stream)]
-    (utilv/close-and-reset! world-c (make-world-chan world-fn input-stream))
-    (swap! main/viz-options assoc-in [:drawing :display-mode]
-           (if (= input-stream :isolated-2d) :two-d :one-d))
-    (with-ui-loading-message
-      (server/init (model-fn n-regions)
-                   @world-c
-                   @main/into-journal
-                   @into-sim))))
+  (with-ui-loading-message
+    (let [init? (nil? @model)]
+      (reset! model (demo/n-region-model (:n-regions @config)))
+      (if init?
+        (server/init model world-c main/into-journal into-sim)
+        (reset! main/step-template (data/step-template-data @model)))
+      (when init?
+        (async/onto-chan world-c (demo/input-seq) false)))))
 
 (def config-template
   [:div.form-horizontal
-   [:div.form-group
-    [:label.col-sm-5 "Input stream:"]
-    [:div.col-sm-7
-     [:select.form-control {:field :list
-                            :id :input-stream}
-      [:option {:key :directional-steps-1d} "directional-steps-1d"]
-      [:option {:key :isolated-1d} "isolated-1d"]
-      [:option {:key :mixed-gaps-1d} "mixed-gaps-1d"]
-      [:option {:key :isolated-2d} "isolated-2d"]]]]
    [:div.form-group
     [:label.col-sm-5 "Encoder:"]
     [:div.col-sm-7
@@ -174,59 +100,36 @@
                            :id :n-regions}]]]
    [:div.form-group
     [:div.col-sm-offset-5.col-sm-7
-     [:button.btn.btn-primary
+     [:button.btn.btn-default
       {:on-click (fn [e]
                    (set-model!)
                    (.preventDefault e))}
       "Restart with new model"]
      [:p.text-danger "This resets all parameters."]]]
 
-   [:dl
-    [:dt [:code "directional-steps-1d"]]
-    [:dd "The input stream steps through integers [0--8] either
-              upwards or downwards, chosen randomly. An indicator of
-              the next step direction is included as part of the
-              input."]
-    [:dt [:code "isolated-1d"]]
-    [:dd "The following fixed sequences are presented one at a
-              time with a gap of 5 time steps. Each new pattern is
-              chosen randomly. This example is designed for testing
-              temporal pooling, as each fixed sequence should give
-              rise to a stable representation."
-     [:pre
-":run-0-5   [0 1 2 3 4 5]
+   [:p "The following fixed sequences are presented one at a time with
+   a gap of 5 time steps. Each new pattern is chosen randomly. This
+   example is designed for testing temporal pooling, as each fixed
+   sequence should give rise to a stable representation."
+    [:pre
+     ":run-0-5   [0 1 2 3 4 5]
 :rev-5-1   [5 4 3 2 1]
 :run-6-10  [6 7 8 9 10]
 :jump-6-12 [6 7 8 11 12]
 :twos      [0 2 4 6 8 10 12 14]
 :saw-10-15 [10 12 11 13 12 14 13 15]"
-      ]]
-    [:dt [:code "mixed-gaps-1d"]]
-    [:dd "The same fixed sequences as above are each repeated
-                with random-length gaps and mixed together."]
-    [:dt [:code "isolated-2d"]]
-    [:dd "The following fixed sequences are presented one at a
-              time with a gap of 5 time steps. Each new pattern is
-              chosen randomly."
-     [:pre
-":down-1     [[1 0] [1 1] [1 2] [1 3] [1 4]
-             [1 5] [1 6] [1 7] [1 8] [1 9]]
-:down-right [[1 0] [1 1] [1 2] [1 3] [1 4]
-             [1 5] [3 5] [5 5] [7 5] [9 5]]
-:diag-tl-br [[0 0] [1 1] [2 2] [3 3] [4 4]
-             [5 5] [6 6] [7 7] [8 8] [9 9]]
-:rand-10    [ten random coordinates]"]]
-    ]
+     ]]
    ])
 
 (defn model-tab
   []
   [:div
-   [:p "These demos are all kinds of fixed sequences."]
+   [:p "Fixed integer patterns repeating in random order."]
    [bind-fields config-template config]
    ])
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
-                  (dom/getElement "comportexviz-app")))
+  (reagent/render [main/comportexviz-app model-tab world-pane (atom into-sim)]
+                  (dom/getElement "comportexviz-app"))
+  (set-model!))

--- a/examples/demos/comportexviz/demos/letters.cljs
+++ b/examples/demos/comportexviz/demos/letters.cljs
@@ -170,7 +170,7 @@ Chifung has a friend."))
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane (atom into-sim)]
+  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
                   (dom/getElement "comportexviz-app"))
   (put! into-sim [:run])
   (set-model!))

--- a/examples/demos/comportexviz/demos/letters.cljs
+++ b/examples/demos/comportexviz/demos/letters.cljs
@@ -5,6 +5,7 @@
             [comportexviz.main :as main]
             [comportexviz.helpers :as helpers]
             [comportexviz.bridge.browser :as server]
+            [comportexviz.server.data :as data]
             [comportexviz.util :as utilv]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]
@@ -25,11 +26,9 @@
               (comp (map (util/keep-history-middleware 300 :value :history))
                     (map #(assoc % :label (:value %))))))
 
-(def into-sim
-  (atom nil))
+(def model (atom nil))
 
-(def model
-  (atom nil))
+(def into-sim (async/chan))
 
 (add-watch model ::count-world-buffer
            (fn [_ _ _ _]
@@ -62,7 +61,7 @@ Chifung has a friend."))
                (fn [_ _ _ [sel]]
                  (when-let [model-id (:model-id sel)]
                    (let [out-c (async/chan)]
-                     (put! @main/into-journal [:get-model model-id out-c])
+                     (put! main/into-journal [:get-model model-id out-c])
                      (go
                        (reset! selected-htm (<! out-c)))))))
     (fn []
@@ -85,19 +84,16 @@ Chifung has a friend."))
 
 (defn set-model!
   []
-  (utilv/close-and-reset! into-sim (async/chan))
-  (utilv/close-and-reset! main/into-journal (async/chan))
-
-  (let [n-regions (:n-regions @config)
-        sensor (case (:encoder @config)
-                 :block demo/block-sensor
-                 :random demo/random-sensor)]
-    (with-ui-loading-message
+  (with-ui-loading-message
+    (let [n-regions (:n-regions @config)
+          sensor (case (:encoder @config)
+                   :block demo/block-sensor
+                   :random demo/random-sensor)
+          init? (nil? @model)]
       (reset! model (demo/n-region-model n-regions demo/spec sensor))
-      (server/init model
-                   world-c
-                   @main/into-journal
-                   @into-sim))))
+      (if init?
+        (server/init model world-c main/into-journal into-sim)
+        (reset! main/step-template (data/step-template-data @model))))))
 
 (defn immediate-key-down!
   [e]
@@ -174,8 +170,7 @@ Chifung has a friend."))
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
+  (reagent/render [main/comportexviz-app model-tab world-pane (atom into-sim)]
                   (dom/getElement "comportexviz-app"))
-  (go
-    (<! (set-model!))
-    (put! @into-sim [:run])))
+  (put! into-sim [:run])
+  (set-model!))

--- a/examples/demos/comportexviz/demos/notebook.cljs
+++ b/examples/demos/comportexviz/demos/notebook.cljs
@@ -88,7 +88,7 @@
                            [viz/viz-timeline steps selection viz-options])
                          [viz/viz-canvas {:tabIndex 0} steps
                           selection step-template viz-options nil nil
-                          (atom into-journal) local-targets]]
+                          into-journal local-targets]]
                         el)))))
 
 (defn ^:export release-viz [el serialized]

--- a/examples/demos/comportexviz/demos/q_learning_1d.cljs
+++ b/examples/demos/comportexviz/demos/q_learning_1d.cljs
@@ -278,6 +278,6 @@
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane (atom into-sim)]
+  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
                   (dom/getElement "comportexviz-app"))
   (set-model!))

--- a/examples/demos/comportexviz/demos/q_learning_1d.cljs
+++ b/examples/demos/comportexviz/demos/q_learning_1d.cljs
@@ -6,6 +6,7 @@
             [comportexviz.helpers :as helpers :refer [resizing-canvas]]
             [comportexviz.plots-canvas :as plt]
             [comportexviz.bridge.browser :as server]
+            [comportexviz.server.data :as data]
             [comportexviz.util :as utilv]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]
@@ -25,11 +26,9 @@
               (comp (map (util/frequencies-middleware :x :freqs))
                     (map #(assoc % :label (:x %))))))
 
-(def into-sim
-  (atom nil))
+(def into-sim (async/chan))
 
-(def model
-  (atom nil))
+(def model (atom nil))
 
 (defn draw-world
   [ctx inval]
@@ -155,7 +154,7 @@
                (fn [_ _ _ [sel]]
                  (when-let [model-id (:model-id sel)]
                    (let [out-c (async/chan)]
-                     (put! @main/into-journal [:get-model model-id out-c])
+                     (put! main/into-journal [:get-model model-id out-c])
                      (go
                        (reset! selected-htm (<! out-c)))))))
     (fn []
@@ -206,17 +205,19 @@
 
 (defn set-model!
   []
-  (utilv/close-and-reset! into-sim (async/chan))
-  (utilv/close-and-reset! main/into-journal (async/chan))
-
   (with-ui-loading-message
-    (reset! model (demo/make-model))
-    (server/init model
-                 world-c
-                 @main/into-journal
-                 @into-sim
-                 (demo/htm-step-with-action-selection world-c))
-    (put! world-c demo/initial-inval)))
+    (let [init? (nil? @model)]
+      (go
+        (when-not init?
+          ;; break cycle to reset input
+          (<! world-c))
+        (reset! model (demo/make-model))
+        (if init?
+          (server/init model world-c main/into-journal into-sim
+                       (demo/htm-step-with-action-selection world-c))
+          (reset! main/step-template (data/step-template-data @model)))
+        ;; seed input
+        (put! world-c demo/initial-inval)))))
 
 (def config-template
   [:div.form-horizontal
@@ -277,6 +278,6 @@
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
+  (reagent/render [main/comportexviz-app model-tab world-pane (atom into-sim)]
                   (dom/getElement "comportexviz-app"))
   (set-model!))

--- a/examples/demos/comportexviz/demos/q_learning_2d.cljs
+++ b/examples/demos/comportexviz/demos/q_learning_2d.cljs
@@ -240,7 +240,7 @@
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane (atom into-sim)]
+  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
                   (dom/getElement "comportexviz-app"))
   (swap! main/viz-options assoc-in [:drawing :display-mode] :two-d)
   (set-model!))

--- a/examples/demos/comportexviz/demos/runner.cljs
+++ b/examples/demos/comportexviz/demos/runner.cljs
@@ -31,6 +31,5 @@
         (put! into-journal [:ping])
         (recur)))
 
-    (reagent/render [main/comportexviz-app model-tab world-pane
-                     (atom into-sim-in)]
+    (reagent/render [main/comportexviz-app model-tab world-pane into-sim-in]
                     (dom/getElement "comportexviz-app"))))

--- a/examples/demos/comportexviz/demos/runner.cljs
+++ b/examples/demos/comportexviz/demos/runner.cljs
@@ -5,8 +5,7 @@
             [reagent.core :as reagent :refer [atom]]
             [goog.dom :as dom]
             [cljs.core.async :as async :refer [put! <!]])
-  (:require-macros [cljs.core.async.macros :refer [go go-loop]]
-                   [comportexviz.macros :refer [with-ui-loading-message]]))
+  (:require-macros [cljs.core.async.macros :refer [go go-loop]]))
 
 (defn world-pane
   [])
@@ -16,12 +15,10 @@
 
 (defn ^:export init
   []
-  (reset! main/into-journal (async/chan))
-
   (let [into-sim-in (async/chan)
         into-sim-mult (async/mult into-sim-in)
         into-sim-eavesdrop (tap-c into-sim-mult)
-        into-journal @main/into-journal
+        into-journal main/into-journal
         pipe-to-remote-target! (bridge/init
                                 (str "ws://" js/location.host "/ws/")
                                 main/local-targets)]

--- a/examples/demos/comportexviz/demos/second_level_motor.cljs
+++ b/examples/demos/comportexviz/demos/second_level_motor.cljs
@@ -215,7 +215,7 @@
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane (atom into-sim)]
+  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
                   (dom/getElement "comportexviz-app"))
 
   (set-model!))

--- a/examples/demos/comportexviz/demos/second_level_motor.cljs
+++ b/examples/demos/comportexviz/demos/second_level_motor.cljs
@@ -6,6 +6,7 @@
             [comportexviz.plots-canvas :as plt]
             [comportexviz.demos.sensorimotor-1d :refer [draw-eye]]
             [comportexviz.bridge.browser :as server]
+            [comportexviz.server.data :as data]
             [comportexviz.util :as utilv]
             [monet.canvas :as c]
             [reagent.core :as reagent :refer [atom]]
@@ -13,8 +14,9 @@
             [goog.dom :as dom]
             [goog.dom.forms :as forms]
             [clojure.string :as str]
-            [cljs.core.async :as async :refer [put!]])
-  (:require-macros [comportexviz.macros :refer [with-ui-loading-message]]))
+            [cljs.core.async :as async :refer [put! <!]])
+  (:require-macros [cljs.core.async.macros :refer [go]]
+                   [comportexviz.macros :refer [with-ui-loading-message]]))
 
 (def config
   (atom {:text demo/test-text}))
@@ -25,7 +27,7 @@
 
 (def control-c (async/chan))
 
-(def into-sim (atom nil))
+(def into-sim (async/chan))
 
 (def model (atom nil))
 
@@ -133,19 +135,20 @@
 
 (defn set-model!
   []
-  (let [] ;; TODO: config
-    (utilv/close-and-reset! into-sim (async/chan))
-    (utilv/close-and-reset! main/into-journal (async/chan))
-
-    (with-ui-loading-message
-      (reset! model (demo/two-region-model))
-      (server/init model
-                   world-c
-                   @main/into-journal
-                   @into-sim
-                   (demo/htm-step-with-action-selection world-c
-                                                        control-c))
-      (put! world-c demo/initial-inval))))
+  (with-ui-loading-message
+    (let [init? (nil? @model)]
+      (go
+        (when-not init?
+          ;; break cycle to reset input
+          (<! world-c))
+        (reset! model (demo/two-region-model))
+        (if init?
+          (server/init model world-c main/into-journal into-sim
+                       (demo/htm-step-with-action-selection world-c
+                                                            control-c))
+          (reset! main/step-template (data/step-template-data @model)))
+        ;; seed input
+        (put! world-c demo/initial-inval)))))
 
 (defn set-text!
   []
@@ -212,7 +215,7 @@
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
+  (reagent/render [main/comportexviz-app model-tab world-pane (atom into-sim)]
                   (dom/getElement "comportexviz-app"))
 
   (set-model!))

--- a/examples/demos/comportexviz/demos/sensorimotor_1d.cljs
+++ b/examples/demos/comportexviz/demos/sensorimotor_1d.cljs
@@ -221,7 +221,7 @@
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane (atom into-sim)]
+  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
                   (dom/getElement "comportexviz-app"))
   (put! into-sim [:run])
   (set-model!))

--- a/examples/demos/comportexviz/demos/simple_sentences.cljs
+++ b/examples/demos/comportexviz/demos/simple_sentences.cljs
@@ -153,7 +153,7 @@
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane (atom into-sim)]
+  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
                   (dom/getElement "comportexviz-app"))
   (put! into-sim [:run])
   (set-model!))

--- a/examples/demos/comportexviz/demos/simple_sentences.cljs
+++ b/examples/demos/comportexviz/demos/simple_sentences.cljs
@@ -5,6 +5,7 @@
             [comportexviz.main :as main]
             [comportexviz.helpers :as helpers]
             [comportexviz.bridge.browser :as server]
+            [comportexviz.server.data :as data]
             [comportexviz.util :as utilv]
             [reagent.core :as reagent :refer [atom]]
             [reagent-forms.core :refer [bind-fields]]
@@ -27,11 +28,9 @@
               (comp (map (util/keep-history-middleware 100 :word :history))
                     (map #(assoc % :label (:word %))))))
 
-(def into-sim
-  (atom nil))
+(def into-sim (async/chan))
 
-(def model
-  (atom nil))
+(def model (atom nil))
 
 (add-watch model ::count-world-buffer
            (fn [_ _ _ _]
@@ -49,7 +48,7 @@
                (fn [_ _ _ [sel]]
                  (when-let [model-id (:model-id sel)]
                    (let [out-c (async/chan)]
-                     (put! @main/into-journal [:get-model model-id out-c])
+                     (put! main/into-journal [:get-model model-id out-c])
                      (go
                        (reset! selected-htm (<! out-c)))))))
 
@@ -74,19 +73,16 @@
 
 (defn set-model!
   []
-  (utilv/close-and-reset! into-sim (async/chan))
-  (utilv/close-and-reset! main/into-journal (async/chan))
-
-  (let [n-regions (:n-regions @config)
-        sensor (case (:encoder @config)
-                 :block (demo/make-block-sensor (:text @config))
-                 :random demo/random-sensor)]
-    (with-ui-loading-message
+  (with-ui-loading-message
+    (let [n-regions (:n-regions @config)
+          sensor (case (:encoder @config)
+                   :block (demo/make-block-sensor (:text @config))
+                   :random demo/random-sensor)
+          init? (nil? @model)]
       (reset! model (demo/n-region-model n-regions demo/spec sensor))
-      (server/init model
-                   world-c
-                   @main/into-journal
-                   @into-sim))))
+      (if init?
+        (server/init model world-c main/into-journal into-sim)
+        (reset! main/step-template (data/step-template-data @model))))))
 
 (defn send-text!
   []
@@ -157,8 +153,7 @@
 
 (defn ^:export init
   []
-  (reagent/render [main/comportexviz-app model-tab world-pane into-sim]
+  (reagent/render [main/comportexviz-app model-tab world-pane (atom into-sim)]
                   (dom/getElement "comportexviz-app"))
-  (go
-    (<! (set-model!))
-    (put! @into-sim [:run])))
+  (put! into-sim [:run])
+  (set-model!))

--- a/src/comportexviz/bridge/browser.cljs
+++ b/src/comportexviz/bridge/browser.cljs
@@ -13,10 +13,8 @@
    (init
     model world-c into-journal into-sim htm-step nil))
   ([model world-c into-journal into-sim htm-step models-out]
-   (let [model-atom (if (satisfies? IDeref model)
-                      model
-                      (atom model))
-         models-in (async/chan)
+   (assert (satisfies? IDeref model))
+   (let [models-in (async/chan)
          models-mult (async/mult models-in)
          into-journal* (async/chan)
          into-sim* (async/chan)
@@ -26,5 +24,5 @@
      (async/pipeline 1 into-journal* client-info-xf into-journal)
      (when models-out
        (async/tap models-mult models-out))
-     (simulation/start models-in model-atom world-c into-sim* htm-step)
-     (journal/init (utilv/tap-c models-mult) into-journal* model-atom 50))))
+     (simulation/start models-in model world-c into-sim* htm-step)
+     (journal/init (utilv/tap-c models-mult) into-journal* model 50))))

--- a/src/comportexviz/controls_ui.cljs
+++ b/src/comportexviz/controls_ui.cljs
@@ -146,9 +146,9 @@
 (defn gather-col-state-history!
   [col-state-history step into-journal local-targets]
   (let [response-c (async/chan)]
-    (put! @into-journal [:get-column-state-freqs
-                         (:model-id step)
-                         (channel-proxy/register! local-targets response-c)])
+    (put! into-journal [:get-column-state-freqs
+                        (:model-id step)
+                        (channel-proxy/register! local-targets response-c)])
     (go
       (let [r (<! response-c)]
         (swap! col-state-history
@@ -333,9 +333,9 @@
         [rgn-id lyr-id] (sel/layer sel1)]
     (when (and bit lyr-id)
       (let [response-c (async/chan)]
-        (put! @into-journal [:get-details-text model-id rgn-id lyr-id bit
-                             (channel-proxy/register! local-targets
-                                                      response-c)])
+        (put! into-journal [:get-details-text model-id rgn-id lyr-id bit
+                            (channel-proxy/register! local-targets
+                                                     response-c)])
         (go
           (reset! text-response (<! response-c)))))))
 
@@ -371,7 +371,7 @@
            [:button.btn.btn-warning.btn-block
             (cond-> {:on-click (fn [e]
                                  (let [response-c (async/chan)]
-                                   (put! @into-journal
+                                   (put! into-journal
                                          [:get-model model-id
                                           (channel-proxy/register! local-targets
                                                                    response-c)

--- a/src/comportexviz/controls_ui.cljs
+++ b/src/comportexviz/controls_ui.cljs
@@ -41,14 +41,13 @@
   (add-watch step-template ::push-to-server
              (fn [_ _ prev-st st]
                (when-not (nil? prev-st) ;; don't push when getting initial template
-                 (assert @into-sim)
                  (doseq [path (for [[r-id rgn] (:regions st)
                                     l-id (keys rgn)]
                                 [:regions r-id l-id :spec])
                          :let [old-spec (get-in prev-st path)
                                new-spec (get-in st path)]]
                    (when (not= old-spec new-spec)
-                     (put! @into-sim [:set-spec path new-spec]))))))
+                     (put! into-sim [:set-spec path new-spec]))))))
 
   (let [partypes (cljs.core/atom {})] ;; write-once cache
     (fn [step-template selection into-sim local-targets]
@@ -69,10 +68,8 @@
                     :let [typ (or (get @partypes k)
                                   (get (swap! partypes assoc k (param-type v))
                                        k))
-                          setv! (if @into-sim
-                                  #(swap! step-template assoc-in spec-path
-                                          (assoc spec k %))
-                                  identity)]]
+                          setv! #(swap! step-template assoc-in spec-path
+                                        (assoc spec k %))]]
                 [:div.row {:class (when (or (nil? v) (string? v))
                                     "has-error")}
                  [:div.col-sm-8
@@ -123,17 +120,14 @@
                  (obviously losing any learned connections in the process):"
                   ]
                  [:button.btn.btn-warning.btn-block
-
-                  (if @into-sim
-                    {:on-click #(helpers/ui-loading-message-until
-                                 (go
-                                   (<! (async/timeout 100))
-                                   (let [finished (async/chan)]
-                                     (put! @into-sim
-                                           [:restart (channel-proxy/register!
-                                                      local-targets finished)])
-                                     (<! finished))))}
-                    {:disabled "disabled"})
+                  {:on-click #(helpers/ui-loading-message-until
+                               (go
+                                 (<! (async/timeout 100))
+                                 (let [finished (async/chan)]
+                                   (put! into-sim
+                                         [:restart (channel-proxy/register!
+                                                    local-targets finished)])
+                                   (<! finished))))}
                   "Rebuild model"]
                  [:p.small "This will not reset, or otherwise alter, the input stream."]]
                 ]
@@ -478,7 +472,7 @@
            :timestep (:timestep (first steps))}))
 
 (defn navbar
-  [steps show-help viz-options viz-expanded into-viz into-sim local-targets]
+  [steps show-help viz-options viz-expanded step-template into-viz into-sim local-targets]
   ;; Ideally we would only show unscroll/unsort/unwatch when they are relevant...
   ;; but that is tricky. An easier option is to hide those until the
   ;; first time they are possible, then always show them. We keep track here:
@@ -490,14 +484,8 @@
         going? (atom false)
         subscriber-c (async/chan)]
 
-    (let [m [:subscribe-to-status (channel-proxy/register! local-targets
-                                                           subscriber-c)]]
-      (add-watch into-sim ::subscribe-to-status
-                 (fn [_ _ _ c]
-                   (when c
-                     (put! c m))))
-      (when @into-sim
-        (put! @into-sim m)))
+    (put! into-sim [:subscribe-to-status (channel-proxy/register! local-targets
+                                                                  subscriber-c)])
 
     (go-loop []
       (when-let [[g?] (<! subscriber-c)]
@@ -537,7 +525,7 @@
             (cond-> {:type :button
                      :on-click (send-command into-viz :step-backward)
                      :title "Step backward in time"}
-              (not @into-sim) (assoc :disabled "disabled"))
+              (not @step-template) (assoc :disabled "disabled"))
             [:span.glyphicon.glyphicon-step-backward {:aria-hidden "true"}]
             [:span.visible-xs-inline " Step backward"]]]
           ;; step forward
@@ -546,24 +534,24 @@
             (cond-> {:type :button
                      :on-click (send-command into-viz :step-forward)
                      :title "Step forward in time"}
-              (not @into-sim) (assoc :disabled "disabled"))
+              (not @step-template) (assoc :disabled "disabled"))
             [:span.glyphicon.glyphicon-step-forward {:aria-hidden "true"}]
             [:span.visible-xs-inline " Step forward"]]]
           ;; pause button
           [:li (when-not @going? {:class "hidden"})
            [:button.btn.btn-default.navbar-btn
             (cond-> {:type :button
-                     :on-click #(put! @into-sim [:pause])
+                     :on-click #(put! into-sim [:pause])
                      :style {:width "5em"}}
-              (not @into-sim) (assoc :disabled "disabled"))
+              (not @step-template) (assoc :disabled "disabled"))
             "Pause"]]
           ;; run button
           [:li (when @going? {:class "hidden"})
            [:button.btn.btn-primary.navbar-btn
             (cond-> {:type :button
-                     :on-click #(put! @into-sim [:run])
+                     :on-click #(put! into-sim [:run])
                      :style {:width "5em"}}
-              (not @into-sim) (assoc :disabled "disabled"))
+              (not @step-template) (assoc :disabled "disabled"))
             "Run"]]
           ;; display mode
           [:li.dropdown
@@ -698,31 +686,31 @@
            [:ul.dropdown-menu {:role "menu"}
             [:li [:a {:href "#"
                       :on-click (fn []
-                                  (put! @into-sim [:set-step-ms 0])
+                                  (put! into-sim [:set-step-ms 0])
                                   (swap! viz-options assoc-in
                                          [:drawing :anim-every] 1))}
                   "max sim speed"]]
             [:li [:a {:href "#"
                       :on-click (fn []
-                                  (put! @into-sim [:set-step-ms 0])
+                                  (put! into-sim [:set-step-ms 0])
                                   (swap! viz-options assoc-in
                                          [:drawing :anim-every] 100))}
                   "max sim speed, draw every 100 steps"]]
             [:li [:a {:href "#"
                       :on-click (fn []
-                                  (put! @into-sim [:set-step-ms 250])
+                                  (put! into-sim [:set-step-ms 250])
                                   (swap! viz-options assoc-in
                                          [:drawing :anim-every] 1))}
                   "limit to 4 steps/sec."]]
             [:li [:a {:href "#"
                       :on-click (fn []
-                                  (put! @into-sim [:set-step-ms 500])
+                                  (put! into-sim [:set-step-ms 500])
                                   (swap! viz-options assoc-in
                                          [:drawing :anim-every] 1))}
                   "limit to 2 steps/sec."]]
             [:li [:a {:href "#"
                       :on-click (fn []
-                                  (put! @into-sim [:set-step-ms 1000])
+                                  (put! into-sim [:set-step-ms 1000])
                                   (swap! viz-options assoc-in
                                          [:drawing :anim-every] 1))}
                   "limit to 1 step/sec."]]]]
@@ -827,8 +815,8 @@
     (fn [model-tab main-pane viz-options selection steps step-template
          series-colors into-viz into-sim into-journal local-targets]
      [:div
-      [navbar steps show-help viz-options viz-expanded into-viz into-sim
-       local-targets]
+      [navbar steps show-help viz-options viz-expanded step-template into-viz
+       into-sim local-targets]
       [help-block show-help]
       [:div.container-fluid
        [:div.row

--- a/src/comportexviz/main.cljs
+++ b/src/comportexviz/main.cljs
@@ -12,7 +12,7 @@
 
 ;;; ## Journal data
 
-(def into-journal (atom nil))
+(def into-journal (async/chan))
 (def local-targets (channel-proxy/registry))
 
 ;;; ## Viz data
@@ -54,6 +54,9 @@
           (recur))))
     steps-c))
 
+;; not sure why this would be used, but for completeness...
+(def subscription-data (subscribe-to-steps! into-journal))
+
 (defn unsubscribe! [subscription-data]
   (let [steps-c subscription-data]
     (async/close! steps-c))
@@ -68,15 +71,6 @@
                                               (:model-id
                                                (nth steps (:dt sel)))))
                                      %))))
-
-(let [subscription-data (atom nil)]
-  (add-watch into-journal ::subscribe-to-steps
-             (fn [_ _ _ into-j]
-               (swap! subscription-data
-                      (fn [sd]
-                        (when sd
-                          (unsubscribe! sd))
-                        (subscribe-to-steps! into-j))))))
 
 ;;; ## Components
 

--- a/src/comportexviz/plots.cljs
+++ b/src/comportexviz/plots.cljs
@@ -301,7 +301,7 @@
         bit (when (= (sel/layer sel) [region-key layer-id]) (:bit sel))]
     (if-let [model-id (:model-id sel)]
       (let [response-c (async/chan)]
-        (put! @into-journal
+        (put! into-journal
               [:get-cell-excitation-data model-id region-key layer-id bit
                (channel-proxy/register! local-targets
                                         response-c)])
@@ -500,10 +500,10 @@
   (when-let [[region layer] (sel/layer sel)]
     (let [model-id (:model-id sel)
           response-c (async/chan)]
-      (put! @into-journal [:get-transitions-data
-                           model-id region layer cell-sdr-counts
-                           (channel-proxy/register!
-                            local-targets response-c)])
+      (put! into-journal [:get-transitions-data
+                          model-id region layer cell-sdr-counts
+                          (channel-proxy/register!
+                           local-targets response-c)])
       response-c)))
 
 (defn calc-sdr-sizes
@@ -568,10 +568,10 @@
         :let [response-c (async/chan)
               model-id (:model-id step)]]
     (go
-      (put! @into-journal [:get-cells-by-state model-id
-                           region layer
-                           (channel-proxy/register! local-targets
-                                                    response-c)])
+      (put! into-journal [:get-cells-by-state model-id
+                          region layer
+                          (channel-proxy/register! local-targets
+                                                   response-c)])
       (let [cells-by-state (<! response-c)
             state (or (get-in @states [(:model-id prev-step) [region layer]])
                       empty-cell-sdrs-state)

--- a/src/comportexviz/util.cljc
+++ b/src/comportexviz/util.cljc
@@ -8,12 +8,6 @@
     (async/tap mult c)
     c))
 
-(defn close-and-reset! [chan-atom v]
-  (swap! chan-atom (fn [c]
-                     (when c
-                       (async/close! c))
-                     v)))
-
 (defn index-of
   [coll pred]
   (first (->> coll

--- a/src/comportexviz/viz_canvas.cljs
+++ b/src/comportexviz/viz_canvas.cljs
@@ -1061,8 +1061,8 @@
                                                   :model-id (:model-id
                                                              (nth @steps dt)))))))
           :step-forward (if (some #(zero? (:dt %)) @selection)
-                          (when (and into-sim @into-sim)
-                            (put! @into-sim [:step]))
+                          (when (and @step-template into-sim)
+                            (put! into-sim [:step]))
                           (swap! selection
                                  #(conj (pop %)
                                         (let [sel1 (peek %)
@@ -1109,8 +1109,8 @@
                                   (grid-layout-paths @viz-layouts)
                                   (map :path @selection))
                                 false))
-          :toggle-run (when (and into-sim @into-sim)
-                        (put! @into-sim [:toggle])))
+          :toggle-run (when (and @step-template into-sim)
+                        (put! into-sim [:toggle])))
         (recur)))
 
     (reagent/create-class


### PR DESCRIPTION
In the Runner, keep a single journal and simulation going, even if the model is reset. This means we can make `into-journal` and `into-sim` always be channels, not wrapped in atoms.

Fixes #27

Oh and I rewrote the fixed-seqs demo page to only show one demo, `isolated-1d`. The others don't really add much and may be confusing. And having different (infinite seq) input streams to switch between -- which was always icky -- really didn't work with this new arrangement.