### PR TITLE
Adjust to new core/predictions signature

### DIFF
--- a/examples/worksheets/hello.clj
+++ b/examples/worksheets/hello.clj
@@ -99,7 +99,7 @@
 (defn t->prediction [t]
   (when (> t 0)
     (-> (nth timeline (dec t))
-        (core/predictions 1)
+        (core/predictions :input 1)
         first
         :value)))
 


### PR DESCRIPTION
Respond to the change in https://github.com/nupic-community/comportex/pull/29

Definitely feel free to ask me to do `core/ff-base` differently. I sorta just added a core API on a whim.