### PR TITLE
Move some text out of the canvas and into the DOM

### DIFF
--- a/examples/demos/comportexviz/demos/runner.cljs
+++ b/examples/demos/comportexviz/demos/runner.cljs
@@ -9,13 +9,12 @@
 
 (defn world-pane
   []
-  (when-let [step (main/selected-step)]
-    (into [:div
-           [:div {:style {:font "10px sans-serif"}} "sensed values"]]
-          (for [[sense-id v] (:sensed-values step)]
-            [:div {:style {:margin-top 30}}
-             [:p (name sense-id) [:br]
-              [:strong (str v)]]]))))
+  (into [:div
+         [:div {:style {:font "10px sans-serif"}} "sensed values"]]
+        (for [[sense-id v] (:sensed-values (main/selected-step))]
+          [:div {:style {:margin-top 30}}
+           [:p (name sense-id) [:br]
+            [:strong (str v)]]])))
 
 (defn ^:export init
   []

--- a/examples/worksheets/worksheet_shrink.clj
+++ b/examples/worksheets/worksheet_shrink.clj
@@ -27,7 +27,7 @@
 
 (let [in-path "examples/worksheets/hello.clj"
       worksheet-out-filename "hello.faster.clj"
-      
+
       date-dir (.format (java.text.SimpleDateFormat. "yyyy.MM.dd.HH.mm.ss") (java.util.Date.))
       out-dir (str "examples/worksheets/" date-dir)
       images-subfolder date-dir
@@ -53,7 +53,7 @@
                                 (spit img-file-path
                                       contents)
                                 (format "<img src='%s' />" img-web-path))))
-            (string/replace #"<img src='data\:image/png;base64,(.*?)' />"
+            (string/replace #"data\:image/png;base64,(.*?)(?=[\"'\\])"
                             (fn [[_ base64-str]]
                               (let [img-filename (str (swap! file-count inc) ".png")
                                     img-web-path (format "%s/%s" images-subfolder img-filename)
@@ -63,6 +63,6 @@
                                 (with-open [out (io/output-stream
                                                   (io/file img-file-path))]
                                   (.write out (base64/decode (.getBytes base64-str))))
-                                (format "<img src='%s' />" img-web-path))))))
+                                img-web-path)))))
   (println "Wrote to" worksheet-out-path))
 ;; @@


### PR DESCRIPTION
Via React, it'll be easy to change the viz-canvas into a mashup of
canvas, divs, SVG, etc. I moved the top labels out of the canvas and
into the DOM. The benefit of this is that browsers are way better at
rendering text in the DOM than in canvases. It's especially noticeable
on Retina screens or when using pinch-to-zoom.

I think it'd be good to move all text labels out of the canvas, and
also write the viz-timeline in SVG (which has the same benefits, but
for shapes as well).

This change just handles the top labels, though, and updates the
notebook to keep it compatible.