### PR TITLE
Handle apical dendrites

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject comportexviz "0.0.11-SNAPSHOT"
+(defproject comportexviz "0.0.12-SNAPSHOT"
   :description "Web visualisation of HTM algorithm as implemented in comportex"
   :url "https://github.com/nupic-community/comportexviz"
 
@@ -6,7 +6,7 @@
                  [org.clojure/clojurescript "1.7.107"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
                  [tailrecursion/cljs-priority-map "1.1.0"]
-                 [org.nfrac/comportex "0.0.11-SNAPSHOT"]
+                 [org.nfrac/comportex "0.0.12-SNAPSHOT"]
                  [rm-hull/monet "0.2.1"]
                  [reagent "0.5.0"]
                  [reagent-forms "0.5.6"]

--- a/src/comportexviz/plots.cljs
+++ b/src/comportexviz/plots.cljs
@@ -813,7 +813,7 @@
             pc (:pred-cells cells-by-state)
             on? (:engaged? cells-by-state)
             threshold (get-in @step-template [:regions region layer
-                                              :spec :seg-learn-threshold])
+                                              :spec :distal :learn-threshold])
             ;; for each cell, represents its specificity to each SDR
             cell-sdr-fracs (->> (:cell-sdr-counts state)
                                 (util/remap freqs->fracs))

--- a/src/comportexviz/server/details.cljc
+++ b/src/comportexviz/server/details.cljc
@@ -82,7 +82,7 @@
                      (if (contains? sig-bits id) " S")
                      (if (contains? bits id)
                        (str " A "
-                            (let [[src-k src-i] (core/source-of-incoming-bit htm rgn-id id)
+                            (let [[src-k src-i] (core/source-of-incoming-bit htm rgn-id id :ff-deps)
                                   src-rgn (get-in htm [:regions src-k])]
                               (if src-rgn
                                 (let [src-cell (p/source-of-bit src-rgn src-i)]

--- a/src/comportexviz/server/details.cljc
+++ b/src/comportexviz/server/details.cljc
@@ -60,12 +60,12 @@
         (let [p-lyr (get-in prior-htm [:regions rgn-id lyr-id])
               p-prox-sg (:proximal-sg p-lyr)
               p-distal-sg (:distal-sg p-lyr)
-              d-pcon (:distal-perm-connected (p/params p-lyr))
-              ff-pcon (:ff-perm-connected (p/params p-lyr))
+              d-pcon (:perm-connected (:distal (p/params p-lyr)))
+              ff-pcon (:perm-connected (:proximal (p/params p-lyr)))
               bits (:in-ff-bits (:state lyr))
               sig-bits (:in-stable-ff-bits (:state lyr))
-              d-bits (:distal-bits (:prior-distal-state lyr))
-              d-lc-bits (:distal-lc-bits (:prior-distal-state lyr))
+              d-bits (:on-bits (:prior-distal-state lyr))
+              d-lc-bits (:on-lc-bits (:prior-distal-state lyr))
               ]
           ["__Column overlap__"
            (str (get (:col-overlaps (:state lyr)) [col 0]))
@@ -75,30 +75,28 @@
            (for [[si syns] (map-indexed vector (p/cell-segments p-prox-sg [col 0]))
                  :when (seq syns)]
              [(str "FF segment " si)
-              (for [[id p] (sort syns)]
-                (str "  " id
+              (for [[id p] (sort syns)
+                    :let [[src-k src-i] (core/source-of-incoming-bit htm rgn-id id :ff-deps)
+                          src-rgn (get-in htm [:regions src-k])
+                          src-id (if src-rgn (p/source-of-bit src-rgn src-i) src-i)
+                          ]]
+                (str "  " src-k " " src-id
                      (if (>= p ff-pcon) " :=> " " :.: ")
                      (to-fixed p 2)
-                     (if (contains? sig-bits id) " S")
-                     (if (contains? bits id)
-                       (str " A "
-                            (let [[src-k src-i] (core/source-of-incoming-bit htm rgn-id id :ff-deps)
-                                  src-rgn (get-in htm [:regions src-k])]
-                              (if src-rgn
-                                (let [src-cell (p/source-of-bit src-rgn src-i)]
-                                  (str src-k " " src-cell))
-                                (str src-k " " src-i)))))))])
-           "__Cells and their Dendrite segments__"
+                     (if (contains? sig-bits id) " S"
+                         (if (contains? bits id) " A"))))])
+           "__Cells and their distal dendrite segments__"
            (for [ci (range (p/layer-depth lyr))
                  :let [segs (p/cell-segments p-distal-sg [col ci])]]
              [(str "CELL " ci)
               (str (count segs) " = " (map count segs))
-              #_(str "Distal excitation from this cell: "
-                     (p/targets-connected-from p-distal-sg (+ ci (* depth col)))) ;; TODO cell->id
               (for [[si syns] (map-indexed vector segs)]
                 [(str "  SEGMENT " si)
-                 (for [[id p] (sort syns)]
-                   (str "  " id
+                 (for [[id p] (sort syns)
+                       :let [[src-k _ src-i] (core/source-of-distal-bit htm rgn-id lyr-id id)
+                             src-rgn (get-in htm [:regions src-k])
+                             src-id (if src-rgn (p/source-of-bit src-rgn src-i) src-i)]]
+                   (str "    " src-k " " src-id
                         (if (>= p d-pcon) " :=> " " :.: ")
                         (to-fixed p 2)
                         (if (contains? d-lc-bits id) " L"

--- a/src/comportexviz/server/journal.cljc
+++ b/src/comportexviz/server/journal.cljc
@@ -181,12 +181,16 @@
                       (id-missing-response id steps-offset))))
 
             :get-cells-segments
-            (let [[id rgn-id lyr-id col ci-si type token response-c] xs
+            (let [[id rgn-id lyr-id col ci-si token response-c] xs
                   [opts] (get-in @client-info [::viewports token])]
               (put! response-c
                     (if-let [[prev-htm htm] (find-model-pair id)]
-                      (data/cells-segments-data htm prev-htm rgn-id lyr-id col
-                                                ci-si type opts)
+                      (let [types [:distal :apical]]
+                        (zipmap
+                         types
+                         (for [type types]
+                           (data/cells-segments-data htm prev-htm rgn-id lyr-id
+                                                     col ci-si type opts))))
                       (id-missing-response id steps-offset))))
 
             :get-details-text

--- a/src/comportexviz/server/journal.cljc
+++ b/src/comportexviz/server/journal.cljc
@@ -181,12 +181,12 @@
                       (id-missing-response id steps-offset))))
 
             :get-cells-segments
-            (let [[id rgn-id lyr-id col ci-si token response-c] xs
+            (let [[id rgn-id lyr-id col ci-si type token response-c] xs
                   [opts] (get-in @client-info [::viewports token])]
               (put! response-c
                     (if-let [[prev-htm htm] (find-model-pair id)]
                       (data/cells-segments-data htm prev-htm rgn-id lyr-id col
-                                                ci-si opts)
+                                                ci-si type opts)
                       (id-missing-response id steps-offset))))
 
             :get-details-text

--- a/src/comportexviz/viz_canvas.cljs
+++ b/src/comportexviz/viz_canvas.cljs
@@ -929,9 +929,10 @@
                          ;; dt may be outdated at this point
                          (reset! cells-segs-response [(dissoc sel1 :dt)
                                                       (<! response-c)]))
+                       ;; TODO: get both distal and apical segments, display side by side, selection?
                        (put! into-journal
                              [:get-cells-segments model-id rgn-id lyr-id bit
-                              cell-seg viewport-token
+                              cell-seg :distal viewport-token
                               (channel-proxy/register! local-targets
                                                        response-c)])
                        true))))


### PR DESCRIPTION
Corresponding change to nupic-community/comportex#35

support new parameters spec structure.

does not yet actually display apical dendrite segments. thinking of showing them side-by-side - each cell would have a vertical line of distal segments and to its right another vertical line of apical segments.

will need to alter the selection structure probably to distinguish distal from apical segments.
