### PR TITLE
Allow servers to send synapses to back to arbitrary timesteps

### DIFF
--- a/src/comportexviz/server/data.cljc
+++ b/src/comportexviz/server/data.cljc
@@ -152,6 +152,7 @@
                                     src-i)]]
                 (cond-> {:src-id src-id
                          :src-col src-col
+                         :src-dt 0
                          :syn-state syn-state}
                   do-perm? (assoc :perm perm)
                   src-lyr (assoc :src-lyr src-lyr)))]
@@ -305,7 +306,8 @@
                                                                       src-i)
 
                                                                     :src-id src-id
-                                                                    :src-lyr src-lyr}
+                                                                    :src-lyr src-lyr
+                                                                    :src-dt 1}
 
                                                              (get-in opts [:distal-synapses :permanences])
                                                              (assoc :perm p))))))))]))}]))))

--- a/src/comportexviz/viz_canvas.cljs
+++ b/src/comportexviz/viz_canvas.cljs
@@ -360,10 +360,10 @@
     (doseq [[[rgn-id lyr-id col] synapses] ff-synapses
             :let [this-lay (get-in r-lays [rgn-id lyr-id])
                   [this-x this-y] (element-xy this-lay col dt)]]
-      (doseq [{:keys [src-id src-col perm src-lyr syn-state]} synapses
+      (doseq [{:keys [src-id src-col perm src-lyr src-dt syn-state]} synapses
               :let [src-lay (or (get s-lays src-id)
                                 (get-in r-lays [src-id src-lyr]))
-                    [src-x src-y] (element-xy src-lay src-col dt)]]
+                    [src-x src-y] (element-xy src-lay src-col (+ dt src-dt))]]
         (doto ctx
           (c/stroke-style (state-colors syn-state))
           (c/alpha (if perm perm 1))
@@ -642,11 +642,12 @@
                       (= draw-from :all))
               (doseq [[syn-state syns] syns-by-state]
                 (c/stroke-style ctx (state-colors syn-state))
-                (doseq [{:keys [src-col src-id src-lyr perm]} syns
+                (doseq [{:keys [src-col src-id src-lyr src-dt perm]} syns
                         :let [src-lay (get-in layouts (if src-lyr
                                                         [:regions src-id src-lyr]
                                                         [:senses src-id]))
-                              [src-x src-y] (element-xy src-lay src-col (inc dt))]]
+                              [src-x src-y] (element-xy src-lay src-col
+                                                        (+ dt src-dt))]]
                   (when perm (c/alpha ctx perm))
                   (doto ctx
                     (c/begin-path)


### PR DESCRIPTION
Specify the source dt as part of a synapse.

This change was wonderfully simple/easy. I just want to check if you like this direction. Currently the client makes some assumptions about how HTM works. This change points to a future where, for example, we might show synapses going back 5 timesteps in a temporal pooling layer.

My real reason for making this change is something less glamorous. In nupic.research they pass pseudo feedback values directly into TemporalMemory, not using feedback from an actual feedforward-determined layer. So the best way to show this feedback input is just to show the apical synapses connecting to the current timestep rather than the previous. Or maybe I'm wrong, maybe I should just shift the inputs over one timestep, but that adds some messiness. Seems worth having this dt option.